### PR TITLE
Look for `data-engine` attribute in parent element

### DIFF
--- a/src/run-python-blocks.ts
+++ b/src/run-python-blocks.ts
@@ -1,6 +1,6 @@
 import type { AppEngine, AppMode } from "./Components/App";
-import { parseCodeBlock } from "./parse-codeblock";
 import type { Component } from "./parse-codeblock";
+import { parseCodeBlock } from "./parse-codeblock";
 // @ts-expect-error: This import is _not_ bundled. It would be nice to be able
 // import type information from ./Components/App (which gets compiled to
 // shinylive.js), but I haven't figured out how to make it do that and do this
@@ -10,14 +10,20 @@ import { runApp } from "./shinylive.js";
 // Select all of the DOM elements that match the combined selector. It's
 // important that they're selected in the order they appear in the page, so that
 // we execute them in the correct order.
-const blocks: NodeListOf<HTMLPreElement> =
-  document.querySelectorAll(".shinylive-python, .shinylive-r");
+const blocks: NodeListOf<HTMLPreElement> = document.querySelectorAll(
+  ".shinylive-python, .shinylive-r"
+);
 
 blocks.forEach((block) => {
   const container = document.createElement("div");
   container.className = "shinylive-wrapper";
 
-  const engine: AppEngine = block.dataset.engine === 'r' ? 'r' : 'python';
+  // Look for the data-engine attribute. It is normally on the .shinylive-xx
+  // element, but the Quarto filter for RevealJS moves the data-engine attribute
+  // to the parent element, so we'll look there as well.
+  const engine: AppEngine = (block.dataset.engine ||
+    block.parentElement?.dataset.engine ||
+    "python") as AppEngine;
 
   // Copy over explicitly-set style properties.
   container.style.cssText = block.style.cssText;

--- a/src/run-python-blocks.ts
+++ b/src/run-python-blocks.ts
@@ -18,12 +18,9 @@ blocks.forEach((block) => {
   const container = document.createElement("div");
   container.className = "shinylive-wrapper";
 
-  // Look for the data-engine attribute. It is normally on the .shinylive-xx
-  // element, but the Quarto filter for RevealJS moves the data-engine attribute
-  // to the parent element, so we'll look there as well.
-  const engine: AppEngine = (block.dataset.engine ||
-    block.parentElement?.dataset.engine ||
-    "python") as AppEngine;
+  const engine: AppEngine = block.classList.contains("shinylive-r")
+    ? "r"
+    : "python";
 
   // Copy over explicitly-set style properties.
   container.style.cssText = block.style.cssText;


### PR DESCRIPTION
This closes #60.

This is the HTML structure that shinylive expects:

```html
<pre class="shinylive-r" data-engine="r"><code>#\| standalone: true
...
```

Shinylive searches for elements with `class="shinylive-r"`, and then looks at the `data-engine` attribute on that element.


However, the RevealJS format for Quarto transforms it into this:

```html
<div class="sourceCode" id="cb2" data-engine="r">
  <pre class="sourceCode numberSource shinylive-r number-lines code-with-copy">
  <code class="sourceCode">
  <span id="cb2-1"><a href="#cb2-1"></a>#\| standalone: true</span>
  ...
```

Note that the `data-engine` attribute is no longer in the same element as `class="shinylive-r"`.


This PR makes it so that it will look for `data-engine` in both the `class="shinylive-r"` element, and the immediate parent.

I think that a better fix might be to update the revealjs format so that it moves `data-` attributes to the child, along with the class.


This document now works:

	---
	title: "Shinylive RevealJS"
	format: revealjs
	filters:
	  - shinylive
	---
	
	## Shinylive Python
	
	```{shinylive-python}
	#| standalone: true
	#| viewerHeight: 420
	from shiny import App, render, ui
	
	app_ui = ui.page_fluid(
	    ui.h2("Hello Shiny!"),
	    ui.input_slider("n", "N", 0, 100, 20),
	    ui.output_text_verbatim("txt"),
	)
	
	
	def server(input, output, session):
	    @output
	    @render.text
	    def txt():
	        return f"n*2 is {input.n() * 2}"
	
	
	app = App(app_ui, server)
	```
	
	## Shinylive R
	
	```{shinylive-r}
	#| standalone: true
	#| viewerHeight: 420
	ui <- fluidPage(
	  sliderInput("obs", "Number of observations:",
	    min = 0, max = 1000, value = 500
	  ),
	  plotOutput("distPlot")
	)
	
	server <- function(input, output) {
	  output$distPlot <- renderPlot({
	    hist(rnorm(input$obs))
	  })
	}
	
	shinyApp(ui, server)
	```
