### PR TITLE
Add a null LSP client for use when not running Python apps

### DIFF
--- a/src/Components/Editor.tsx
+++ b/src/Components/Editor.tsx
@@ -6,6 +6,7 @@
 import * as fileio from "../fileio";
 import { createUri } from "../language-server/client";
 import { LSPClient } from "../language-server/lsp-client";
+import { ensureNullClient } from "../language-server/null-client";
 import { ensurePyrightClient } from "../language-server/pyright-client";
 import { inferFiletype, modKeySymbol, stringToUint8Array } from "../utils";
 import type { AppEngine, UtilityMethods } from "./App";
@@ -97,7 +98,9 @@ export default function Editor({
   // lsp-extensions.ts, and useTabbedCodeMirror.tsx, there are explicit checks
   // that files are python files in order to enable LS features, and they should
   // not be necessary at this level.
-  const lspClient: LSPClient = ensurePyrightClient();
+  const lspClient: LSPClient = appEngine === 'python'
+    ? ensurePyrightClient()
+    : ensureNullClient();
 
   // A unique ID for this instance of the Editor. At some point it might make
   // sense to hoist this up into the App component, if we need unique IDs for

--- a/src/language-server/null-client.ts
+++ b/src/language-server/null-client.ts
@@ -1,0 +1,46 @@
+import { createUri, LanguageServerClient } from "./client";
+import { LSPClient } from "./lsp-client";
+import {
+  AbstractMessageReader,
+  AbstractMessageWriter,
+  createMessageConnection,
+} from "vscode-jsonrpc";
+
+let nullClient: NullClient | null = null;
+
+/**
+ * This returns a NullClient object. If this is called multiple times, it
+ * will return the same object each time.
+ */
+export function ensureNullClient(): NullClient {
+  if (!nullClient) {
+    nullClient = new NullClient();
+  }
+  return nullClient;
+}
+
+export class NullMessageReader extends AbstractMessageReader {
+  public listen() {
+    return { dispose: () => {} };
+  }
+}
+
+export class NullMessageWriter extends AbstractMessageWriter {
+  public async write() {}
+  public end(): void {}
+}
+
+/**
+ * A "null" LSP client that listens for messages but does nothing.
+ */
+export class NullClient extends LSPClient {
+  constructor() {
+    const conn = createMessageConnection(
+      new NullMessageReader(),
+      new NullMessageWriter()
+    );
+    conn.listen();
+    const client = new LanguageServerClient(conn, "en", createUri(""));
+    super(client);
+  }
+}


### PR DESCRIPTION
This PR adds a new "null" LSP client. The LSP client starts up, but does nothing. Writing out messages is ignored and incoming messages are never generated.

The idea here is rather than conditionally executing code in many places related to setting up and using the pyright LSP, we can instead create a dummy LSP that does nothing for use when running R Shiny apps.

Later, we can add a new R LSP client class and switch to using that for R apps instead.

Such a null LSP client might also be useful in the future as part of an abstract client that delegates messages to the various LSP servers we eventually support, with the null client as a fallback to quietly handle file types where there is no LSP server.

With this change, shinylive should no longer try to read any files from `/pyright` or `/pyodide` when running with the R engine.
