### PR TITLE
Determine engine from first arg in codeblock-to-json.ts

### DIFF
--- a/src/Components/HeaderBar.tsx
+++ b/src/Components/HeaderBar.tsx
@@ -1,5 +1,6 @@
 import shinyPyLogo from "../assets/shiny-for-python.svg";
 import shinyRLogo from "../assets/shiny-logo.svg";
+import { engineSwitch } from "../utils";
 import { AppEngine } from "./App";
 import "./HeaderBar.css";
 import { Icon } from "./Icons";
@@ -122,8 +123,8 @@ export default function HeaderBar({
   const mainUrl = {
     python: "https://shiny.posit.co/py/",
     r: "https://shiny.posit.co/",
-  }
-  const shinyLogo = appEngine === "python" ? shinyPyLogo : shinyRLogo;
+  };
+  const shinyLogo = engineSwitch(appEngine, shinyRLogo, shinyPyLogo);
 
   return (
     <div className="HeaderBar">

--- a/src/parse-codeblock.ts
+++ b/src/parse-codeblock.ts
@@ -1,6 +1,7 @@
+import { load as yamlLoad } from "js-yaml";
 import { AppEngine } from "./Components/App";
 import type { FileContent } from "./Components/filecontent";
-import { load as yamlLoad } from "js-yaml";
+import { engineSwitch } from "./utils";
 
 export type Component = "editor" | "terminal" | "viewer" | "examples" | "cell";
 
@@ -38,7 +39,10 @@ export type QuartoArgs = {
  * iVBORw0KGgoAAAANSUhEUgAAACgAAAAuCAYAAABap1twAAAABGdBTUEAALGPC ...
  * ------------------------------
  */
-export function parseCodeBlock(codeblock: string | string[], engine: AppEngine): {
+export function parseCodeBlock(
+  codeblock: string | string[],
+  engine: AppEngine
+): {
   files: FileContent[];
   quartoArgs: Required<QuartoArgs>;
 } {
@@ -66,7 +70,7 @@ export function parseCodeBlock(codeblock: string | string[], engine: AppEngine):
       );
     }
     // For shiny apps, the default filename is "app.py" or "app.R".
-    defaultFilename = engine === 'python' ? 'app.py' : 'app.R';
+    defaultFilename = engineSwitch(engine, "app.R", "app.py");
   } else {
     // In the case of editor-terminal and editor-cell components...
     if (quartoArgs.standalone !== false) {

--- a/src/parse-codeblock.ts
+++ b/src/parse-codeblock.ts
@@ -78,7 +78,8 @@ export function parseCodeBlock(
         "'#| standalone: true' is not valid for editor-terminal and editor-cell code blocks."
       );
     }
-    defaultFilename = "code.py";
+
+    defaultFilename = engineSwitch(engine, "code.R", "code.py");
   }
 
   const files = parseFileContents(lines, defaultFilename);

--- a/src/scripts/codeblock-to-json.ts
+++ b/src/scripts/codeblock-to-json.ts
@@ -12,6 +12,7 @@
 // import to work at run time, because the output path structure is different.
 import { readLines } from "https://deno.land/std/io/mod.ts";
 
+import type { AppEngine } from "../Components/App";
 import { parseCodeBlock } from "../parse-codeblock";
 
 const { args } = Deno;
@@ -20,7 +21,9 @@ const lines: string[] = [];
 for await (const line of readLines(Deno.stdin)) {
   lines.push(line);
 }
+// Default to python to support legacy codeblocks with an old version of shinylive quarto extension
+const engine: AppEngine = args.length > 0 && args[0] == "r" ? "r" : "python";
 
-const content = parseCodeBlock(lines);
+const content = parseCodeBlock(lines, engine);
 
 await Deno.stdout.write(new TextEncoder().encode(JSON.stringify(content)));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import type { AppEngine } from "./Components/App";
+
 // =======================================================================
 // Utility functions
 // =======================================================================
@@ -140,4 +142,20 @@ export function stringToUint8Array(s: string): Uint8Array {
     bytes[i] = s.charCodeAt(i);
   }
   return bytes;
+}
+
+export function engineSwitch(
+  engine: AppEngine,
+  rValue: string,
+  pythonValue: string
+): string {
+  switch (engine) {
+    case "r":
+      return rValue;
+
+    // Legacy default engine value was `python`
+    case "python":
+    default:
+      return pythonValue;
+  }
 }


### PR DESCRIPTION
Pass in `engine` as first `arg` to `codeblock-to-json.js` so that quarto extension can tell which language is being used.