### PR TITLE
Switch COEP header from `require-corp` to `credentialless`

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -264,7 +264,7 @@ if (serve) {
                     proxyRes.headers = {
                       ...proxyRes.headers,
                       "cross-origin-opener-policy": "same-origin",
-                      "cross-origin-embedder-policy": "require-corp",
+                      "cross-origin-embedder-policy": "credentialless",
                       "cross-origin-resource-policy": "cross-origin",
                     };
                   }

--- a/src/messageporthttp.ts
+++ b/src/messageporthttp.ts
@@ -259,7 +259,7 @@ export async function makeHttpuvRequest(
 
     const headers = Object.assign(
       {
-        "cross-origin-embedder-policy": "require-corp",
+        "cross-origin-embedder-policy": "credentialless",
         "cross-origin-resource-policy": "cross-origin",
       },
       Object.fromEntries(

--- a/src/shinylive-sw.ts
+++ b/src/shinylive-sw.ts
@@ -20,7 +20,7 @@ const version = "v6";
 // for cross-origin isolation. Required when using webR.
 function addCoiHeaders(resp: Response): Response {
   const headers = new Headers(resp.headers);
-  headers.set("Cross-Origin-Embedder-Policy", "require-corp");
+  headers.set("Cross-Origin-Embedder-Policy", "credentialless");
   headers.set("Cross-Origin-Resource-Policy", "cross-origin");
   headers.set("Cross-Origin-Opener-Policy", "same-origin");
   return new Response(resp.body, {


### PR DESCRIPTION
See https://github.com/posit-dev/r-shinylive/issues/51#issuecomment-1923433562 and [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy#directives) for details.

With this change, cross-origin requests for embedded content are sent without credentials and so the responses are allowed without an explicit permission via the CORP header in the response. This fixes embedding certain types of content in webR Shinylive apps, while still allowing the option of using cross-origin isolation and `SharedArrayBuffer` with webR.

Fixes https://github.com/posit-dev/r-shinylive/issues/49 (embedding MathJax) and https://github.com/posit-dev/r-shinylive/issues/51 (embedding openstreetmap)
