### PR TITLE
Use shinyswatch >= 0.5.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,4 @@ packaging>=21.3
 requirements-parser>=0.5.0
 typing-extensions
 pyright
-shinyswatch
+shinyswatch>=0.5.1


### PR DESCRIPTION
From https://github.com/posit-dev/py-shinyswatch/issues/31 it appears that shinyswatch is out of date.

I'm not sure if this is the right place to ensure that we use a recent version of shinyswatch, but it seemed likely.