### PR TITLE
S3: Set content-type for Shiny for R library.data

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,9 +89,11 @@ jobs:
           AWS_CLOUDFRONT_DISTRIBUTION_ID: "E2SN9UWE8YY9EG"
         run: |
           pip install awscli
+          gzip -k _shinylive/r/shinylive/webr/library.data
           aws s3 sync _shinylive s3://shinylive.io --delete
           aws s3 cp --exclude "*" --include "*.data" --include "*.so" --recursive --content-type="application/wasm" --metadata-directive="REPLACE" s3://shinylive.io/r/shinylive/webr/ s3://shinylive.io/r/shinylive/webr/
           aws s3 cp --exclude "*" --include "*.js.metadata" --recursive --content-type="text/javascript" --metadata-directive="REPLACE" s3://shinylive.io/r/shinylive/webr/ s3://shinylive.io/r/shinylive/webr/
+          aws s3 cp --content-encoding="gzip" --content-type="application/wasm" --metadata-directive="REPLACE" _shinylive/r/shinylive/webr/library.data.gz s3://shinylive.io/r/shinylive/webr/library.data
           aws cloudfront create-invalidation --distribution-id $AWS_CLOUDFRONT_DISTRIBUTION_ID --paths "/*"
 
       # =====================================================

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,6 +90,8 @@ jobs:
         run: |
           pip install awscli
           aws s3 sync _shinylive s3://shinylive.io --delete
+          aws s3 cp --exclude "*" --include "*.data" --include "*.so" --recursive --content-type="application/wasm" --metadata-directive="REPLACE" s3://shinylive.io/r/shinylive/webr/ s3://shinylive.io/r/shinylive/webr/
+          aws s3 cp --exclude "*" --include "*.js.metadata" --recursive --content-type="text/javascript" --metadata-directive="REPLACE" s3://shinylive.io/r/shinylive/webr/ s3://shinylive.io/r/shinylive/webr/
           aws cloudfront create-invalidation --distribution-id $AWS_CLOUDFRONT_DISTRIBUTION_ID --paths "/*"
 
       # =====================================================


### PR DESCRIPTION
With this, the content type for the file `library.data` is set to `"application/wasm"` in S3. CloudFront compresses files with such content-type using GZIP encoding over the wire.

Update: Due to AWS file-size limits on automatic GZIP compression I've updated the PR so that `library.data` is compressed at the S3 source. The browser still decompresses on the fly.