### PR TITLE
Update browser URL hash when user presses play button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shinylive",
-  "version": "0.2.8",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shinylive",
-      "version": "0.2.8",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@codemirror/autocomplete": "^6.4.2",
@@ -61,6 +61,7 @@
         "prettier-plugin-organize-imports": "^3.2.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-hot-toast": "^2.4.1",
         "tsx": "^4.7.0",
         "typescript": "^5.3.3",
         "vscode-languageserver-protocol": "^3.17.5",
@@ -4982,6 +4983,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/goober": {
+      "version": "2.1.14",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.14.tgz",
+      "integrity": "sha512-4UpC0NdGyAFqLNPnhCT2iHpza2q+RAY3GV85a/mRPdzyPQMsj0KmMMuetdIkzWRbJ+Hgau1EZztq8ImmiMGhsg==",
+      "dev": true,
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -8437,6 +8447,22 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.4.1.tgz",
+      "integrity": "sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==",
+      "dev": true,
+      "dependencies": {
+        "goober": "^2.1.10"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-icons": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "prettier-plugin-organize-imports": "^3.2.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hot-toast": "^2.4.1",
     "tsx": "^4.7.0",
     "typescript": "^5.3.3",
     "vscode-languageserver-protocol": "^3.17.5",
@@ -142,6 +143,5 @@
       "react-hooks/rules-of-hooks": "error",
       "react-hooks/exhaustive-deps": "warn"
     }
-  },
-  "packageManager": "yarn@3.2.3"
+  }
 }

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -176,6 +176,7 @@ const buildmap = {
       "src/pyodide-worker.ts",
       "src/load-shinylive-sw.ts",
       "src/run-python-blocks.ts",
+      "src/lzstring-worker.ts",
     ],
     outdir: `${BUILD_DIR}/shinylive`,
     // See note in esbuild.build() call above about why these are external.

--- a/site_template/editor/index.html
+++ b/site_template/editor/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -18,6 +18,13 @@
         allowCodeUrl: true,
         allowGistUrl: true,
         allowExampleUrl: true,
+        // This option causes shinylive to update the URL hash when the user
+        // clicks on the re-run button in the editor. It is false by default.
+        // It should be set to true only when the editor and viewer are used
+        // in a full-window configuration. If you are using the editor and
+        // viewer embedded in a larger page, it does not make sense to set
+        // this to true.
+        updateUrlHashOnRerun: true,
       };
 
       const appRoot = document.getElementById("root");

--- a/site_template/examples/index.html
+++ b/site_template/examples/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -15,11 +15,23 @@
       // reasons, if you enable any of these, then this site should be hosted on
       // a separate domain or subdomain from other content. Otherwise the
       // running of arbitrary code could be used, for example, to steal cookies.
-      runApp(appRoot, "examples-editor-terminal-viewer", {
-        allowCodeUrl: true,
-        allowGistUrl: true,
-        allowExampleUrl: true,
-      }, "{{APP_ENGINE}}");
+      runApp(
+        appRoot,
+        "examples-editor-terminal-viewer",
+        {
+          allowCodeUrl: true,
+          allowGistUrl: true,
+          allowExampleUrl: true,
+          // This option causes shinylive to update the URL hash when the user
+          // clicks on the re-run button in the editor. It is false by default.
+          // It should be set to true only when the editor and viewer are used
+          // in a full-window configuration. If you are using the editor and
+          // viewer embedded in a larger page, it does not make sense to set
+          // this to true.
+          updateUrlHashOnRerun: true,
+        },
+        "{{APP_ENGINE}}",
+      );
     </script>
     <link rel="stylesheet" href="../shinylive/style-resets.css" />
     <link rel="stylesheet" href="../shinylive/shinylive.css" />

--- a/src/Components/App.tsx
+++ b/src/Components/App.tsx
@@ -91,6 +91,10 @@ type AppOptions = {
 
   // In Viewer-only mode, should the header bar be shown?
   showHeaderBar?: boolean;
+
+  // When the app is re-run from the Editor, should the URL hash be updated with
+  // the encoded version of the app?
+  updateUrlHashOnRerun?: boolean;
 };
 
 export type ProxyHandle = PyodideProxyHandle | WebRProxyHandle;
@@ -353,6 +357,7 @@ export function App({
                   file.name === "app.R" ||
                   file.name === "server.R",
               )}
+              updateUrlHashOnRerun={appOptions.updateUrlHashOnRerun}
               appEngine={appEngine}
             />
           </React.Suspense>
@@ -400,6 +405,7 @@ export function App({
                   file.name === "app.R" ||
                   file.name === "server.R",
               )}
+              updateUrlHashOnRerun={appOptions.updateUrlHashOnRerun}
               appEngine={appEngine}
             />
           </React.Suspense>
@@ -433,6 +439,7 @@ export function App({
             terminalMethods={terminalMethods}
             utilityMethods={utilityMethods}
             runOnLoad={false}
+            updateUrlHashOnRerun={appOptions.updateUrlHashOnRerun}
             appEngine={appEngine}
           />
         </React.Suspense>
@@ -458,6 +465,7 @@ export function App({
             lineNumbers={false}
             showHeaderBar={false}
             floatingButtons={true}
+            updateUrlHashOnRerun={appOptions.updateUrlHashOnRerun}
             appEngine={appEngine}
           />
         </React.Suspense>
@@ -495,6 +503,7 @@ export function App({
             terminalMethods={terminalMethods}
             utilityMethods={utilityMethods}
             viewerMethods={viewerMethods}
+            updateUrlHashOnRerun={appOptions.updateUrlHashOnRerun}
             appEngine={appEngine}
           />
         </React.Suspense>

--- a/src/Components/Editor.tsx
+++ b/src/Components/Editor.tsx
@@ -81,6 +81,7 @@ export default function Editor({
   lineNumbers = true,
   showHeaderBar = true,
   floatingButtons = false,
+  updateUrlHashOnRerun = false,
   appEngine,
 }: {
   currentFilesFromApp: FileContent[];
@@ -97,6 +98,7 @@ export default function Editor({
   lineNumbers?: boolean;
   showHeaderBar?: boolean;
   floatingButtons?: boolean;
+  updateUrlHashOnRerun?: boolean;
   appEngine: AppEngine;
 }) {
   // In the future, instead of directly instantiating the PyrightClient, it
@@ -188,8 +190,10 @@ export default function Editor({
     syncActiveFileState();
     const fileContents = editorFilesToFileContents(files);
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    updateBrowserUrlHash(fileContents);
+    if (updateUrlHashOnRerun) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      updateBrowserUrlHash(fileContents);
+    }
 
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     (async () => {

--- a/src/Components/share.ts
+++ b/src/Components/share.ts
@@ -1,4 +1,6 @@
 import LZString from "lz-string";
+import type * as LZStringWorker from "../lzstring-worker";
+import * as utils from "../utils";
 import type { AppEngine } from "./App";
 import type { FileContent } from "./filecontent";
 import { FCtoFCJSON } from "./filecontent";
@@ -29,4 +31,81 @@ export function fileContentsToUrlString(
   return LZString.compressToEncodedURIComponent(
     JSON.stringify(fileContents.map(FCtoFCJSON)),
   );
+}
+
+/**
+ * Given a FileContent[] object, return a string that is a LZ-compressed JSON
+ * representation of it. This version uses a web worker to do the compression.
+ */
+export async function fileContentsToUrlStringInWebWorker(
+  fileContents: FileContent[],
+  sort: boolean = true,
+): Promise<string> {
+  if (sort) {
+    fileContents.sort((a, b) => a.name.localeCompare(b.name));
+  }
+  const fileContentJsonString = JSON.stringify(fileContents.map(FCtoFCJSON));
+  return await encodeLzstringWebWorker(fileContentJsonString);
+}
+
+// =============================================================================
+// Code for calling lzstring with a web worker
+// =============================================================================
+
+// Narrow the types for postMessage to just the type we'll actually send.
+interface LZStringWebWorker extends Omit<Worker, "postMessage"> {
+  postMessage(
+    msg: LZStringWorker.RequestMessage,
+    transfer: Transferable[],
+  ): void;
+}
+
+let _lzstringWebWorker: LZStringWebWorker | null = null;
+
+/**
+ * Ensure that the lzstring web worker exists.
+ *
+ * @returns The lzstring web worker. If it doesn't exist, it will be created.
+ */
+function ensureLzstringWebWorker(): LZStringWebWorker {
+  if (_lzstringWebWorker === null) {
+    _lzstringWebWorker = new Worker(
+      utils.currentScriptDir() + "/lzstring-worker.js",
+      { type: "module" },
+    );
+  }
+  return _lzstringWebWorker;
+}
+
+/**
+ * Compress a string using lzstring in a web worker.
+ */
+async function encodeLzstringWebWorker(value: string): Promise<string> {
+  const response = await postMessageLzstringWebWorker({
+    type: "encode",
+    value,
+  });
+  return response.value;
+}
+
+/**
+ * Send a message to the lzstring web worker and return a promise that resolves
+ * when the worker responds.
+ */
+async function postMessageLzstringWebWorker(
+  msg: LZStringWorker.RequestMessage,
+): Promise<LZStringWorker.ResponseMessage> {
+  const worker = ensureLzstringWebWorker();
+
+  return new Promise((onSuccess) => {
+    const channel = new MessageChannel();
+
+    channel.port1.onmessage = (e) => {
+      channel.port1.close();
+      const msg = e.data as LZStringWorker.ResponseMessage;
+      onSuccess(msg);
+    };
+
+    worker.postMessage(msg, [channel.port2]);
+  });
 }

--- a/src/lzstring-worker.ts
+++ b/src/lzstring-worker.ts
@@ -1,0 +1,40 @@
+// LZString in a Web Worker
+
+import LZString from "lz-string";
+
+self.onmessage = function (e: MessageEvent): void {
+  const msg = e.data as RequestMessage;
+  const messagePort: ResponseMesssagePort = e.ports[0];
+
+  let result: string;
+
+  if (msg.type === "encode") {
+    result = LZString.compressToEncodedURIComponent(msg.value);
+  } else if (msg.type === "decode") {
+    result = LZString.decompressFromEncodedURIComponent(msg.value);
+  } else {
+    throw new Error(`Unknown request message type: ${(msg as any).type}`);
+  }
+
+  messagePort.postMessage({ value: result });
+};
+
+interface ResponseMesssagePort extends Omit<MessagePort, "postMessage"> {
+  postMessage(msg: ResponseMessage): void;
+}
+
+export interface RequestMessageEncode {
+  type: "encode";
+  value: string;
+}
+
+export interface RequestMessageDecode {
+  type: "decode";
+  value: string;
+}
+
+export type RequestMessage = RequestMessageEncode | RequestMessageDecode;
+
+export interface ResponseMessage {
+  value: string;
+}


### PR DESCRIPTION
This closes #128. When the user presses the play button, it will automatically update the URL hash.

The encoding is done in a web worker, so it will not block the main thread.

A few remaining tasks:
- [x] Don't auto-update the if files are very large -- need to figure out how to indicate to user in those cases that they should click the share button.
- [x] Only update the URL if shinylive is in full-page mode on the examples/ or editor/ URL. Don't update if a shinylive app is embedded in another web page, or if someone is editing an app that they've created a static deployment for.
- [x] Maybe don't auto-update if the code is loaded from a gist? Not sure what the behavior should be for this case.
- [x] Only update the URL if the code has been changed (this might not be necessary, though).