### PR TITLE
feat: enable client-side dev mode features in R

### DIFF
--- a/src/Components/Viewer.tsx
+++ b/src/Components/Viewer.tsx
@@ -187,8 +187,8 @@ export function Viewer({
             env: { files, appDir },
             captureStreams: false,
           });
-          await webRProxy.runRAsync(".start_app(appName, appDir)", {
-            env: { appName, appDir },
+          await webRProxy.runRAsync(".start_app(appName, appDir, devMode)", {
+            env: { appName, appDir, devMode },
             captureConditions: false,
             captureStreams: false,
           });

--- a/src/hooks/useWebR.tsx
+++ b/src/hooks/useWebR.tsx
@@ -295,7 +295,7 @@ webr::shim_install()
   lapply(rownames(installed.packages()), function(p) { .webr_pkg_cache[[p]] <<- TRUE })
 }
 
-.start_app <- function(appName, appDir) {
+.start_app <- function(appName, appDir, devMode = FALSE) {
   # Mount VFS images provided in Shinylive app assets
   .mount_vfs_images()
 
@@ -312,6 +312,11 @@ webr::shim_install()
     }
   })
 
+  if (isTRUE(devMode)) {
+    # Enable client-side dev mode features, namely the error console
+    options(shiny.client_devmode = TRUE)
+  }
+  
   app <- .shiny_to_httpuv(appDir)
   assign(appName, app, envir = .shiny_app_registry)
   invisible(0)


### PR DESCRIPTION
Pairs with https://github.com/rstudio/shiny/pull/4073

When `devMode` is `true`, we set `shiny.client_devmode = TRUE` to turn on client-side developer features like the error console.