### PR TITLE
feat: Add `editorHeight` option

### DIFF
--- a/src/Components/App.css
+++ b/src/Components/App.css
@@ -114,5 +114,9 @@ for it. */
 }
 
 .shinylive-container.editor-cell .editor-container {
+  padding: 0;
+}
+
+.shinylive-container.editor-cell .cm-scroller {
   padding: 12px 12px 4px 12px;
 }

--- a/src/Components/App.tsx
+++ b/src/Components/App.tsx
@@ -437,7 +437,7 @@ export function App({
       <ResizableGrid
         className="shinylive-container"
         areas={[["editor", "terminal"]]}
-        rowSizes={["1fr"]}
+        rowSizes={[asCssLengthUnit(appOptions.editorHeight) || "1fr"]}
         colSizes={["1fr", "1fr"]}
       >
         <React.Suspense fallback={<div>Loading...</div>}>

--- a/src/Components/App.tsx
+++ b/src/Components/App.tsx
@@ -25,7 +25,7 @@ import type { FileContent, FileContentJson } from "./filecontent";
 import { FCorFCJSONtoFC } from "./filecontent";
 import { fetchGist, gistApiResponseToFileContents } from "./gist";
 import { editorUrlPrefix, fileContentsToUrlString } from "./share";
-import { asCssLengthUnit } from "./utils";
+import { asCssLengthUnit, minCssLengthUnit } from "./utils";
 
 // Load Editor component dynamically and lazily because it's large and not
 // needed for all configurations.
@@ -85,6 +85,9 @@ type AppOptions = {
 
   // Height of viewer in pixels (number) or as a CSS string (e.g. 3rem).
   viewerHeight?: number | string;
+
+  // Height of the editor in pixels (number) or as a CSS string (e.g. 3rem).
+  editorHeight?: number | string;
 
   // If the ExampleSelector component is present, which example, if any, should
   // start selected?
@@ -384,6 +387,12 @@ export function App({
         ></HeaderBar>
         <ResizableGrid
           className="shinylive-container"
+          style={{
+            height: minCssLengthUnit(
+              appOptions.editorHeight,
+              appOptions.viewerHeight,
+            ),
+          }}
           areas={[
             ["editor", "viewer"],
             ["terminal", "viewer"],
@@ -478,20 +487,24 @@ export function App({
     );
   } else if (appMode === "editor-viewer") {
     const layout = appOptions.layout ?? "horizontal";
-    const viewerHeight = asCssLengthUnit(appOptions.viewerHeight) || "200px";
+    const viewerHeight = asCssLengthUnit(appOptions.viewerHeight);
+    const editorHeight = asCssLengthUnit(appOptions.editorHeight);
 
-    const gridDef =
-      layout === "horizontal"
-        ? {
-            areas: [["editor", "viewer"]],
-            rowSizes: ["1fr"],
-            colSizes: ["1fr", "1fr"],
-          }
-        : {
-            areas: [["editor"], ["viewer"]],
-            rowSizes: ["auto", viewerHeight],
-            colSizes: ["1fr"],
-          };
+    let gridDef;
+    if (layout === "vertical") {
+      gridDef = {
+        areas: [["editor"], ["viewer"]],
+        rowSizes: [editorHeight || "auto", viewerHeight || "200px"],
+        colSizes: ["1fr"],
+      };
+    } else {
+      // horizontal layout
+      gridDef = {
+        areas: [["editor", "viewer"]],
+        rowSizes: [minCssLengthUnit(editorHeight, viewerHeight) || "1fr"],
+        colSizes: ["1fr", "1fr"],
+      };
+    }
 
     return (
       <ResizableGrid className="shinylive-container editor-viewer" {...gridDef}>

--- a/src/Components/App.tsx
+++ b/src/Components/App.tsx
@@ -477,6 +477,7 @@ export function App({
             floatingButtons={true}
             updateUrlHashOnRerun={appOptions.updateUrlHashOnRerun}
             appEngine={appEngine}
+            style={{ height: asCssLengthUnit(appOptions.editorHeight) }}
           />
         </React.Suspense>
         <OutputCell

--- a/src/Components/Editor.tsx
+++ b/src/Components/Editor.tsx
@@ -88,6 +88,7 @@ export default function Editor({
   floatingButtons = false,
   updateUrlHashOnRerun = false,
   appEngine,
+  style,
 }: {
   currentFilesFromApp: FileContent[];
   setCurrentFiles: React.Dispatch<React.SetStateAction<FileContent[]>>;
@@ -105,6 +106,7 @@ export default function Editor({
   floatingButtons?: boolean;
   updateUrlHashOnRerun?: boolean;
   appEngine: AppEngine;
+  style?: React.CSSProperties;
 }) {
   // In the future, instead of directly instantiating the PyrightClient, it
   // would make sense to abstract it out to a class which in turn can run
@@ -615,7 +617,7 @@ export default function Editor({
   // ===========================================================================
 
   return (
-    <div className="shinylive-editor">
+    <div className="shinylive-editor" style={style}>
       {shareModal}
       {showHeaderBar ? (
         <div className="editor-header">

--- a/src/Components/ResizableGrid/ResizableGrid.tsx
+++ b/src/Components/ResizableGrid/ResizableGrid.tsx
@@ -9,15 +9,17 @@ export function ResizableGrid({
   areas,
   rowSizes,
   colSizes,
+  style = {},
 }: {
   className?: string;
   children?: React.ReactNode;
   areas: string[][];
   rowSizes: string[];
   colSizes: string[];
+  style?: React.CSSProperties;
 }) {
   const containerRef = React.useRef<HTMLDivElement>(null);
-  const styles = {
+  const styleGrid = {
     gridTemplateAreas: areas.map((x) => `"${x.join(" ")}"`).join(" \n "),
     gridTemplateRows: rowSizes.join(" "),
     gridTemplateColumns: colSizes.join(" "),
@@ -42,7 +44,11 @@ export function ResizableGrid({
   if (className) classes.push(className);
 
   return (
-    <div className={classes.join(" ")} ref={containerRef} style={styles}>
+    <div
+      className={classes.join(" ")}
+      ref={containerRef}
+      style={{ ...style, ...styleGrid }}
+    >
       {columnSizers.map((gap_index) => (
         <div
           key={"col" + gap_index}

--- a/src/Components/utils.ts
+++ b/src/Components/utils.ts
@@ -13,3 +13,31 @@ export function asCssLengthUnit(value?: number | string): string | undefined {
 
   return `${value}px`;
 }
+
+export function minCssLengthUnit(
+  x?: number | string,
+  y?: number | string,
+  ignoreAuto: boolean = true,
+): string | undefined {
+  x = asCssLengthUnit(x);
+  y = asCssLengthUnit(y);
+
+  if (ignoreAuto) {
+    x = x === "auto" ? undefined : x;
+    y = y === "auto" ? undefined : y;
+  }
+
+  if (x === undefined && y === undefined) {
+    return undefined;
+  }
+
+  if (x && !y) {
+    return x;
+  }
+
+  if (!x && y) {
+    return y;
+  }
+
+  return `min(${x}, ${y})`;
+}


### PR DESCRIPTION
* Fixes https://github.com/quarto-ext/shinylive/issues/33

This PR builds on #140 to incorporate an `editorHeight` option. Editor height has the same semantics as `viewerHeight` (hence the dependency on #140), where users can provide a numeric value taken as pixels or a string, taken as a CSS value.

I updated the following layouts to use `editorHeight`

1. `editor-viewer`
	* In a vertical layout, `editorHeight` and `viewerHeight` are supplied to `grid-template-rows`. In other words, the editor and viewer are independently sized. The default value is `auto, 200px` (editor, viewer).
	* In a horizontal layout, the editor and viewer are next to each other. In this case, setting either `editorHeight` or `viewerHeight` can constrain the overall height of the component. If both are set (to values other than `auto`), we take the minimum height of the two.

2. `editor-terminal-viewer`
	* This app mode is functionally equivalent to `editor-viewer` in a horizontal layout, but we apply the `height` to the `.shinylive-container` element, leaving `grid-template-rows` to determine the relative size of the editor/terminal cells. If either are set, we apply the height constrain to the overall component, using the minimum if both are set.

3. `editor-terminal`
	* Applies `editorHeight` to the overall component via `grid-template-rows`. Sidenote: this view isn't available in Quarto.

4. `editor-cell`
	* Applies `editorHeight` to the `Editor` component. I adjusted padding a bit so that the scroll bars of the editor are at the edges of the editor container.

## Testing

Prior to this PR, in most situations, the shinylive component is generally driven by the code height. The example document below contains a large single-file app that exhibits this behavior. With this PR, the overall component height is configurable in Quarto documents.

<details>
<summary>Example document</summary>

````markdown
---
title: Shinylive in Quarto example
format: html
filters:
  - shinylive
---

This is a Shinylive application embedded in a Quarto doc.

```{shinylive-python}
#| standalone: true
#| layout: vertical
#| components: [editor, terminal, viewer]
#| editorHeight: 700px
#| viewerHeight: 600px

from shiny import *

app_ui = ui.page_fluid(
    ui.input_slider("n", "N", 0, 100, 40),
    ui.output_text_verbatim("txt"),
)

def server(input, output, session):
    @output
    @render.text
    def txt():
        return f"The value of n*2 is {input.n() * 2}"

app = App(app_ui, server)

# 1
# 2
# 3
# 4
# 5
# 6
# 7
# 8
# 9
# 10
# 11
# 12
# 13
# 14
# 15
# 16
# 17
# 18
# 19
# 20
# 21
# 22
# 23
# 24
# 25
# 26
# 27
# 28
# 29
# 30
# 31
# 32
# 33
# 34
# 35
# 36
# 37
# 38
# 39
# 40
# 41
# 42
# 43
# 44
# 45
# 46
# 47
# 48
# 49
# 50
# 51
# 52
# 53
# 54
# 55
# 56
# 57
# 58
# 59
# 60
# 61
# 62
# 63
# 64
# 65
# 66
# 67
# 68
# 69
# 70
# 71
# 72
# 73
# 74
# 75
# 76
# 77
# 78
# 79
# 80
# 81
# 82
# 83
# 84
# 85
# 86
# 87
# 88
# 89
# 90
# 91
# 92
# 93
# 94
# 95
# 96
# 97
# 98
# 99
# 100
```

````

</details>