### PR TITLE
feat: Restructure and expand `export_template` files

### DIFF
--- a/export_template/edit/index.html
+++ b/export_template/edit/index.html
@@ -1,34 +1,11 @@
-<!DOCTYPE html>
-<html lang="en">
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Shiny examples browser</title>
-    <script
-      src="../{{REL_PATH}}shinylive/load-shinylive-sw.js"
-      type="module"
-    ></script>
-    <script src="../{{REL_PATH}}shinylive/jquery.min.js"></script>
-    <script src="../{{REL_PATH}}shinylive/jquery.terminal/js/jquery.terminal.min.js"></script>
-    <link
-      href="../{{REL_PATH}}shinylive/jquery.terminal/css/jquery.terminal.min.css"
-      rel="stylesheet"
+    <title>Redirect to editable app</title>
+    <meta
+      http-equiv="refresh"
+      content="0;URL='../index.html?mode=editor-terminal-viewer'"
     />
-    <script type="module">
-      import { runApp } from "../{{REL_PATH}}shinylive/shinylive.js";
-      const response = await fetch("../app.json");
-      if (!response.ok) {
-        throw new Error("HTTP error loading app.json: " + response.status);
-      }
-      const appFiles = await response.json();
-
-      const appRoot = document.getElementById("root");
-      runApp(appRoot, "editor-terminal-viewer", {startFiles: appFiles}, "{{APP_ENGINE}}");
-    </script>
-    <link rel="stylesheet" href="../{{REL_PATH}}shinylive/style-resets.css" />
-    <link rel="stylesheet" href="../{{REL_PATH}}shinylive/shinylive.css" />
   </head>
-  <body>
-    <div style="height: 100vh; width: 100vw" id="root"></div>
-  </body>
+  <body></body>
 </html>

--- a/export_template/index.html
+++ b/export_template/index.html
@@ -1,28 +1,24 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Shiny App</title>
+    <title>{{title}}</title>
     <script
       src="./{{REL_PATH}}shinylive/load-shinylive-sw.js"
       type="module"
     ></script>
     <script type="module">
-      import { runApp } from "./{{REL_PATH}}shinylive/shinylive.js";
-      const response = await fetch("./app.json");
-      if (!response.ok) {
-        throw new Error("HTTP error loading app.json: " + response.status);
-      }
-      const appFiles = await response.json();
-
-      const appRoot = document.getElementById("root");
-      runApp(appRoot, "viewer", {startFiles: appFiles}, "{{APP_ENGINE}}");
+      import { runExportedApp } from "./{{REL_PATH}}shinylive/shinylive.js";
+      runExportedApp("root", "{{APP_ENGINE}}", "{{REL_PATH}}");
     </script>
     <link rel="stylesheet" href="./{{REL_PATH}}shinylive/style-resets.css" />
     <link rel="stylesheet" href="./{{REL_PATH}}shinylive/shinylive.css" />
+    {{ include_in_head }}
   </head>
   <body>
+    {{ include_before_body }}
     <div style="height: 100vh; width: 100vw" id="root"></div>
+    {{ include_after_body }}
   </body>
 </html>

--- a/export_template/index.html
+++ b/export_template/index.html
@@ -12,7 +12,11 @@
     ></script>
     <script type="module">
       import { runExportedApp } from "./{{REL_PATH}}shinylive/shinylive.js";
-      runExportedApp("root", "{{APP_ENGINE}}", "{{REL_PATH}}");
+      runExportedApp({
+        id: "root",
+        appEngine: "{{APP_ENGINE}}",
+        relPath: "{{REL_PATH}}",
+      });
     </script>
     <link rel="stylesheet" href="./{{REL_PATH}}shinylive/style-resets.css" />
     <link rel="stylesheet" href="./{{REL_PATH}}shinylive/shinylive.css" />

--- a/export_template/index.html
+++ b/export_template/index.html
@@ -14,11 +14,11 @@
     </script>
     <link rel="stylesheet" href="./{{REL_PATH}}shinylive/style-resets.css" />
     <link rel="stylesheet" href="./{{REL_PATH}}shinylive/shinylive.css" />
-    {{ include_in_head }}
+    {{{ include_in_head }}}
   </head>
   <body>
-    {{ include_before_body }}
+    {{{ include_before_body }}}
     <div style="height: 100vh; width: 100vw" id="root"></div>
-    {{ include_after_body }}
+    {{{ include_after_body }}}
   </body>
 </html>

--- a/export_template/index.html
+++ b/export_template/index.html
@@ -3,7 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>{{title}}</title>
+    {{#title}}
+    <title>{{.}}</title>
+    {{/title}}
     <script
       src="./{{REL_PATH}}shinylive/load-shinylive-sw.js"
       type="module"

--- a/src/Components/App.tsx
+++ b/src/Components/App.tsx
@@ -593,7 +593,7 @@ export async function runExportedApp({
   let appMode = urlParams.get("mode") ?? "viewer";
 
   if (!AppModes.includes(appMode)) {
-    console.log(`[shinylive] Unrecognized app mode: ${appMode}`);
+    console.warn(`[shinylive] Unrecognized app mode: ${appMode}`);
     appMode = "viewer";
   }
 

--- a/src/Components/App.tsx
+++ b/src/Components/App.tsx
@@ -75,6 +75,15 @@ export type AppMode =
   | "editor-cell"
   | "viewer";
 
+const AppModes = [
+  "examples-editor-terminal-viewer",
+  "editor-terminal-viewer",
+  "editor-terminal",
+  "editor-viewer",
+  "editor-cell",
+  "viewer",
+];
+
 type AppOptions = {
   // An optional set of files to start with.
   startFiles?: FileContentJson[] | FileContent[];
@@ -555,6 +564,55 @@ export function App({
   } else {
     throw new Error("Have yet to setup this view mode");
   }
+}
+
+// This function helps launch apps exported with the shinylive Python and R
+// packages and is used by `export_template/index.html`.
+export async function runExportedApp(
+  id: string,
+  appEngine: AppEngine,
+  relPath = "",
+) {
+  const response = await fetch("./app.json");
+  if (!response.ok) {
+    throw new Error("HTTP error loading app.json: " + response.status);
+  }
+  const appFiles = await response.json();
+
+  const appRoot = document.getElementById(id);
+  if (!appRoot) {
+    throw new Error(`Could not find app root element with id "${id}"`);
+  }
+
+  // Get `appMode` from the URL query string
+  const urlParams = new URLSearchParams(window.location.search);
+  let appMode = urlParams.get("mode") ?? "viewer";
+
+  if (!AppModes.includes(appMode)) {
+    console.log(`[shinylive] Unrecognized app mode: ${appMode}`);
+    appMode = "viewer";
+  }
+
+  if (appMode.includes("terminal")) {
+    // Load additional dependencies for the terminal
+    // jQuery
+    const jQueryScript = document.createElement("script");
+    jQueryScript.src = `./${relPath}shinylive/jquery.min.js`;
+    document.head.appendChild(jQueryScript);
+
+    // jquery.terminal
+    const terminalJs = document.createElement("script");
+    terminalJs.src = `./${relPath}shinylive/jquery.terminal/js/jquery.terminal.min.js`;
+    document.head.appendChild(terminalJs);
+
+    // terminal CSS
+    const terminalCss = document.createElement("link");
+    terminalCss.rel = "stylesheet";
+    terminalCss.href = `./${relPath}shinylive/jquery.terminal/css/jquery.terminal.min.css`;
+    document.head.appendChild(terminalCss);
+  }
+
+  runApp(appRoot, appMode as AppMode, { startFiles: appFiles }, appEngine);
 }
 
 // The exported function that can be used for embedding into a web page.

--- a/src/Components/App.tsx
+++ b/src/Components/App.tsx
@@ -568,11 +568,15 @@ export function App({
 
 // This function helps launch apps exported with the shinylive Python and R
 // packages and is used by `export_template/index.html`.
-export async function runExportedApp(
-  id: string,
-  appEngine: AppEngine,
+export async function runExportedApp({
+  id,
+  appEngine,
   relPath = "",
-) {
+}: {
+  id: string;
+  appEngine: AppEngine;
+  relPath: string;
+}) {
   const response = await fetch("./app.json");
   if (!response.ok) {
     throw new Error("HTTP error loading app.json: " + response.status);

--- a/src/Components/App.tsx
+++ b/src/Components/App.tsx
@@ -597,25 +597,6 @@ export async function runExportedApp({
     appMode = "viewer";
   }
 
-  if (appMode.includes("terminal")) {
-    // Load additional dependencies for the terminal
-    // jQuery
-    const jQueryScript = document.createElement("script");
-    jQueryScript.src = `./${relPath}shinylive/jquery.min.js`;
-    document.head.appendChild(jQueryScript);
-
-    // jquery.terminal
-    const terminalJs = document.createElement("script");
-    terminalJs.src = `./${relPath}shinylive/jquery.terminal/js/jquery.terminal.min.js`;
-    document.head.appendChild(terminalJs);
-
-    // terminal CSS
-    const terminalCss = document.createElement("link");
-    terminalCss.rel = "stylesheet";
-    terminalCss.href = `./${relPath}shinylive/jquery.terminal/css/jquery.terminal.min.css`;
-    document.head.appendChild(terminalCss);
-  }
-
   runApp(appRoot, appMode as AppMode, { startFiles: appFiles }, appEngine);
 }
 


### PR DESCRIPTION
This PR consolidates the JavaScript for launching an exported shiny app into `runExportedApp()` to avoid duplicating logic between the `index.html` template file and `edit/index.html`:

* Adds `{{title}}` as a template parameter.
* Consolidate app-launching code in `runExportedApp()`.
* Pick up app mode from the `mode` query parameter.
* `edit/index.html` now redirects to `index.html?mode=editor-terminal-viewer`.
* Adds template parameters for additional content:
	* `{{{include_in_head}}}` for content just before `</head>`
	* `{{{include_before_body}}}` for content just after `<body>`
	* `{{{include_after_body}}}` for content just before `</body>`

These changes are intended to help with

* https://github.com/posit-dev/r-shinylive/issues/32#issuecomment-2195013283
* https://github.com/posit-dev/shinylive/issues/110

Ready for review in conjunction with the following PRs. I've tested this PR in both Python and R exports, but let me know if I can provide guidance for testing locally.

* https://github.com/posit-dev/r-shinylive/pull/96
* https://github.com/posit-dev/py-shinylive/pull/32