### PR TITLE
feat: Add `layout-${layout}` class to `editor-viewer` mode

### DIFF
--- a/src/Components/App.tsx
+++ b/src/Components/App.tsx
@@ -517,7 +517,10 @@ export function App({
     }
 
     return (
-      <ResizableGrid className="shinylive-container editor-viewer" {...gridDef}>
+      <ResizableGrid
+        className={`shinylive-container editor-viewer layout-${layout}`}
+        {...gridDef}
+      >
         <React.Suspense fallback={<div>Loading...</div>}>
           <Editor
             currentFilesFromApp={currentFiles}

--- a/src/Components/Editor.css
+++ b/src/Components/Editor.css
@@ -16,7 +16,8 @@
 
 /* Enforce a max height for the editor-viewer mode unless the user has dragged
 the size bigger.  */
-.ResizableGrid.editor-viewer:not(.been-dragged) > .shinylive-editor {
+.ResizableGrid.editor-viewer.layout-vertical:not(.been-dragged)
+  > .shinylive-editor {
   max-height: 800px;
 }
 


### PR DESCRIPTION
A small change to add `.layout-vertical` or `.layout-horizontal` to the `.editor-viewer` container depending on the app layout.

We then use this class to only limit the editor height to 800px when in `.layout-vertical`. Otherwise the editor is not resizable vertically and this limitation artificially constrains the editor height.