### PR TITLE
chore: Use `_shinylive-mode` for query parameter in exported apps

### DIFF
--- a/export_template/edit/index.html
+++ b/export_template/edit/index.html
@@ -4,7 +4,7 @@
     <title>Redirect to editable app</title>
     <meta
       http-equiv="refresh"
-      content="0;URL='../index.html?mode=editor-terminal-viewer'"
+      content="0;URL='../index.html?_shinylive-mode=editor-terminal-viewer'"
     />
   </head>
   <body></body>

--- a/src/Components/App.tsx
+++ b/src/Components/App.tsx
@@ -593,7 +593,7 @@ export async function runExportedApp({
 
   // Get `appMode` from the URL query string
   const urlParams = new URLSearchParams(window.location.search);
-  let appMode = urlParams.get("mode") ?? "viewer";
+  let appMode = urlParams.get("_shinylive-mode") ?? "viewer";
 
   if (!AppModes.includes(appMode)) {
     console.warn(`[shinylive] Unrecognized app mode: ${appMode}`);


### PR DESCRIPTION
Uses `_shinylive-mode` instead of plain `mode` to make it easier to identify shinylive query string parameters and to stay out of the way of app params if #79 is completed in the future.