### PR TITLE
Avoid intercepting network requests in the service worker when we don't need to

### DIFF
--- a/src/shinylive-sw.ts
+++ b/src/shinylive-sw.ts
@@ -186,16 +186,14 @@ self.addEventListener("fetch", function (event): void {
     return;
   }
 
-  event.respondWith(
-    (async (): Promise<Response> => {
-      const resp = await fetch(request);
-      if (coiRequested) {
+  if (coiRequested) {
+    event.respondWith(
+      (async (): Promise<Response> => {
+        const resp = await fetch(request);
         return addCoiHeaders(resp);
-      } else {
-        return resp;
-      }
-    })(),
-  );
+      })(),
+    );
+  }
 });
 
 // =============================================================================


### PR DESCRIPTION
When we're not intercepting a Wasm app URL and not adding COI headers to a request, we can avoid a (potentially many MB) copy in the service worker by not intercepting the request at all.

This should reduce noise in the Network tab of web browsers' devtools, and provide a minor performance boost when fetching additional content for webR, such as `.../cairo.so`