### PR TITLE
Avoid Partial Content HTTP download in webR, fixing browser caching for `cairo.so`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,10 @@ webr:
 	cp -r node_modules/webr/dist/. $(BUILD_DIR)/shinylive/webr
 	curl --fail -L https://github.com/r-wasm/shiny/releases/download/v$(R_SHINY_VERSION)/library.data -o $(BUILD_DIR)/shinylive/webr/library.data
 	curl --fail -L https://github.com/r-wasm/shiny/releases/download/v$(R_SHINY_VERSION)/library.js.metadata -o $(BUILD_DIR)/shinylive/webr/library.js.metadata
+# FIXME: GitHub Pages does not cache Partial Content downloads. Here, we reduce
+# the damage by forcing entire file downloads with Emscripten's lazy filesystem.
+# Potentially, we can add a switch to Emscripten to disable the mechanism.
+	sed -i.bak 's/if(!hasByteServing)//' $(BUILD_DIR)/shinylive/webr/R.bin.js
 
 # Copy pyodide.js and .d.ts to src/pyodide/. This is a little weird in that in
 # `make all`, it comes after downloading pyodide. In the future we may be able


### PR DESCRIPTION
Github Pages supports serving content with HTTP status 206, "Partial Content", but content that is served in this way is not cached by the brower (at least, not by Chrome). So, when using Shinylive hosted on GitHub Pages multiple (slow!) network requests are sent on every page load for the webR resource file `cairo.so`, even if the file has already been previously downloaded by the browser.

Emscripten is configured to fetch lazy filesystem content with size greater than 1MB in chunks, using the partial content mechanism. The chunk size is hard coded [here](https://github.com/emscripten-core/emscripten/blob/ec14ddf11ac3bc594aa9b75a8633e5f22aa84cd4/src/library_fs.js#L1694) and I can't see a way to disable things. We might be able to submit a PR to Emscripten implementing such a disable switch, but even so this would then still require upgrading Emscripten for a new release of webR, which we can't do until R 4.5.0 for ABI reasons.

For the moment, this PR patches the lazy file system mechanism to always skip partial content and download the entire file. With this, `cairo.so` is loaded in a single request, and the response is cached as expected.

R package library content should not be affected, since webR uses a custom VFS mounting routine for those in any case. Also, the patch only touches webR, pyodide should not be affected in any way. AFAICT, the only file large enough in webR's base distribution to be affected in this way will be `cairo.so` itself.