### PR TITLE
Post message to parent when ready

### DIFF
--- a/src/Components/App.tsx
+++ b/src/Components/App.tsx
@@ -8,6 +8,7 @@ import {
 } from "../examples";
 import type { PyodideProxyHandle } from "../hooks/usePyodide";
 import { initPyodide, initShiny, usePyodide } from "../hooks/usePyodide";
+import { useRunOnceOnMount } from "../hooks/useRunOnceOnMount";
 import type { WebRProxyHandle } from "../hooks/useWebR";
 import { initRShiny, initWebR, useWebR } from "../hooks/useWebR";
 import type { ProxyType } from "../pyodide-proxy";
@@ -328,6 +329,12 @@ export function App({
       window.removeEventListener("message", listener);
     };
   }, [currentFiles, setCurrentFiles, editorMethods]);
+
+  useRunOnceOnMount(() => {
+    if (window.parent === window) return;
+
+    window.parent.postMessage({ type: "shinyliveAppReady" }, "*");
+  });
 
   const [utilityMethods, setUtilityMethods] = React.useState<UtilityMethods>({
     formatCode: async (code: string) => {

--- a/src/Components/App.tsx
+++ b/src/Components/App.tsx
@@ -333,7 +333,7 @@ export function App({
   useRunOnceOnMount(() => {
     if (window.parent === window) return;
 
-    window.parent.postMessage({ type: "shinyliveAppReady" }, "*");
+    window.parent.postMessage({ type: "shinyliveReady" }, "*");
   });
 
   const [utilityMethods, setUtilityMethods] = React.useState<UtilityMethods>({

--- a/src/hooks/useRunOnceOnMount.tsx
+++ b/src/hooks/useRunOnceOnMount.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+/**
+ * Executes a callback function only once when the component mounts.
+ *
+ * @param {Function} callback - The callback function to be executed on mount.
+ */
+export function useRunOnceOnMount(callback: () => void) {
+  // This is needed to prevent the callback from being run twice -- in React
+  // strict mode, a useEffect will run twice.
+  const hasRun = React.useRef(false);
+
+  React.useEffect(() => {
+    if (!hasRun.current) {
+      callback();
+      hasRun.current = true;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}


### PR DESCRIPTION
If there is a parent window, the `App` will now post a message to the parent when it is ready.

Notes:
- Currently, "ready" means that it is ready to receive `setFiles` messages posted to the this window, but conceivably one might want to have signals of other events (like when the app actually starts running), so it might make sense to have a message type that can represent multiple types of events.