### PR TITLE
webR: Continue initialisation even if package mounting fails

### DIFF
--- a/src/hooks/useWebR.tsx
+++ b/src/hooks/useWebR.tsx
@@ -282,17 +282,19 @@ webr::shim_install()
       available <- data$cached
       mountpoint <- glue::glue("/shinylive/webr/packages/{name}")
 
-      # Mount the virtual filesystem image, unless we already have done so
-      if (available && !file.exists(mountpoint)) {
-        webr::mount(mountpoint, glue::glue("{.base_url}{path}"))
-      }
+      try({
+        # Mount the virtual filesystem image, unless we already have done so
+        if (available && !file.exists(mountpoint)) {
+          webr::mount(mountpoint, glue::glue("{.base_url}{path}"))
+        }
 
-      # If this is a full library, add it to .libPaths()
-      if(data$type == "library") {
-        paths <- .libPaths()
-        paths <- append(paths, mountpoint , after = length(paths) - 1)
-        .libPaths(paths)
-      }
+        # If this is a full library, add it to .libPaths()
+        if(data$type == "library") {
+          paths <- .libPaths()
+          paths <- append(paths, mountpoint , after = length(paths) - 1)
+          .libPaths(paths)
+        }
+      })
     })
   }
 


### PR DESCRIPTION
A first step in handling https://github.com/quarto-ext/shinylive/issues/59.

This wraps the mounting of bundled Wasm R packages in a `try()`, so that if something goes wrong (e.g. the `.data` file is not there for whatever reason) we recover and continue without the package, and try to start the Shiny app anyway.

This will likely be OK, since the missing package will instead be picked up from the public https://repo.r-wasm.org repo when (and if) it is actually used, which was always intended to be the fallback mode for when a required package is not included in the bundled Wasm assets.

Closes #163.