### PR TITLE
Set title of window from Shiny app title

### DIFF
--- a/site_template/app/index.html
+++ b/site_template/app/index.html
@@ -23,6 +23,10 @@
           allowCodeUrl: true,
           allowGistUrl: true,
           allowExampleUrl: true,
+          setWindowTitle: {
+            prefix: "",
+            defaultTitle: document.title,
+          },
         },
         "{{APP_ENGINE}}",
       );

--- a/site_template/editor/index.html
+++ b/site_template/editor/index.html
@@ -26,6 +26,10 @@
         // viewer embedded in a larger page, it does not make sense to set
         // this to true.
         updateUrlHashOnRerun: true,
+        setWindowTitle: {
+          prefix: "Shiny - ",
+          defaultTitle: document.title,
+        },
       };
 
       const appRoot = document.getElementById("root");

--- a/src/Components/App.tsx
+++ b/src/Components/App.tsx
@@ -110,6 +110,17 @@ type AppOptions = {
   // When the app is re-run from the Editor, should the URL hash be updated with
   // the encoded version of the app?
   updateUrlHashOnRerun?: boolean;
+
+  // Set window title based on the application iframe's title? If this is
+  // not false, then the title from the Viewer iframe will be applied to the
+  // window, with the prefix prepended. If the Viewer iframe's title is empty,
+  // then the default title will be used instead.
+  setWindowTitle?:
+    | {
+        prefix: string;
+        defaultTitle: string;
+      }
+    | false;
 };
 
 export type ProxyHandle = PyodideProxyHandle | WebRProxyHandle;
@@ -420,6 +431,7 @@ export function App({
             proxyHandle={proxyHandle}
             setViewerMethods={setViewerMethods}
             devMode={true}
+            setWindowTitle={appOptions.setWindowTitle}
           />
         </ResizableGrid>
       </>
@@ -470,6 +482,7 @@ export function App({
             proxyHandle={proxyHandle}
             setViewerMethods={setViewerMethods}
             devMode={true}
+            setWindowTitle={appOptions.setWindowTitle}
           />
         </ResizableGrid>
       </>
@@ -574,6 +587,7 @@ export function App({
           proxyHandle={proxyHandle}
           setViewerMethods={setViewerMethods}
           devMode={true}
+          setWindowTitle={appOptions.setWindowTitle}
         />
       </ResizableGrid>
     );
@@ -596,6 +610,7 @@ export function App({
             proxyHandle={proxyHandle}
             setViewerMethods={setViewerMethods}
             devMode={false}
+            setWindowTitle={appOptions.setWindowTitle}
           />
         </div>
       </>


### PR DESCRIPTION
For the `editor/` and `app/` pages, the window title now changes depending on the Viewer iframe's title (this is the Shiny app's title).

- If the title for the Shiny app is "Calculator":
  - For the `editor/` page, the window title will now be "Shiny - Calculator".
  - For the `app/` page, the window title will now be "Calculator".
- If the title for the Shiny app is not set, or the empty string:
  - For the `editor/` page, the window title will now be "Shiny editor".
  - For the `app/` page, the window title will now be "Shiny App".
