### PR TITLE
fix: Install full pkg requirement not just name

### DIFF
--- a/src/hooks/usePyodide.tsx
+++ b/src/hooks/usePyodide.tsx
@@ -413,7 +413,7 @@ async def _install_requirements_from_dir(dir: str) -> None:
 
         if pkg_name not in micropip.list():
             print(f"Installing {pkg_name} ...")
-            await micropip.install(pkg_name)
+            await micropip.install(req)
 
         if len(extras) == 0:
             continue


### PR DESCRIPTION
Fixes posit-dev/py-shinylive#45