### PR TITLE
fix: Fix installation of extra packages

### DIFF
--- a/src/hooks/usePyodide.tsx
+++ b/src/hooks/usePyodide.tsx
@@ -412,8 +412,9 @@ async def _install_requirements_from_dir(dir: str) -> None:
                 extras.update({e.strip() for e in match_extras.group(2).split(",")})
 
         if pkg_name not in micropip.list():
-            print(f"Installing {req} ...")
-            await micropip.install(req)
+            # Install package req without extras, which we handle ourselves
+            # because micropip.install() doesn't actually install extras
+            await micropip.install(re.sub(r"\\[[^\\]]*\\]", "", req))
 
         if len(extras) == 0:
             continue

--- a/src/hooks/usePyodide.tsx
+++ b/src/hooks/usePyodide.tsx
@@ -412,9 +412,11 @@ async def _install_requirements_from_dir(dir: str) -> None:
                 extras.update({e.strip() for e in match_extras.group(2).split(",")})
 
         if pkg_name not in micropip.list():
+            print(f"\\nInstalling {req} ...", end=" ", flush=True)
             # Install package req without extras, which we handle ourselves
             # because micropip.install() doesn't actually install extras
             await micropip.install(re.sub(r"\\[[^\\]]*\\]", "", req))
+            print("done.", flush=True)
 
         if len(extras) == 0:
             continue
@@ -447,8 +449,9 @@ async def _install_requirements_from_dir(dir: str) -> None:
                 for extra_req in extra_reqs:
                     extra_req_name = re.sub(r"([a-zA-Z0-9._,-]+)(.*)", r"\\1", extra_req).strip()
                     if extra_req_name not in micropip.list():
-                        print(f"Installing {extra_req_name} for {pkg_name}[{extra}]")
+                        print(f"\\nInstalling {extra_req_name} for {pkg_name}[{extra}] ...", end=" ", flush = True)
                         await micropip.install(extra_req_name)
+                        print("done.", flush = True)
 
 
 async def _load_packages_from_dir(dir: str) -> None:


### PR DESCRIPTION
In #194 we went back to calling

```python
micropip.install(f"{req}")
```

because otherwise we lose information like the requested package version.

But this broke installation of package extras because it appears that `micropip.install()` doesn't actually install the packages listed in an extra, but somehow `micropip.list()` includes the package names after the installation. This sounds like a bug in micropip or maybe we need to use micropip differently? My memory from when I implemented #187 was that this was known behavior; now when looking again it seems that extras *should* be installed.

In either case, calling `micropip.install("shiny[theme]")` in shinylive doesn't result in any of the `theme` extra packages being installed, but somehow the packages _are_ listed in `micropip.list()`.

So in order to actually install the extras packages, we have to remove extra annotations from the package reqs, e.g. `shiny[theme]` → `shiny`, and then we manually look up the packages in the extra and install them ourselves. This behavior was broken in #194 when we went from installing the package by name back to the full requirement string.

While here, I also improved the UX of the console message. As [pointed out on Discord](https://discord.com/channels/1109483223987277844/1318357786379161731/1318536291750641674) the messages say `Installing {req} ...` and the last message seems to hang. This PR adds `done` to each line when the package install finishes.