### PR TITLE
feat: Support `#|`, `# |` and `##|` for quarto metadata comment indicators

### DIFF
--- a/src/parse-codeblock.ts
+++ b/src/parse-codeblock.ts
@@ -88,18 +88,19 @@ export function parseCodeBlock(
 
 /**
  *  Loop through all the lines and extract lines at the beginning which start
- *  with Quarto parameter comments and have the format "#| " as `quartoArgs`,
- *  and strip those lines from the result. Also remove up to one empty line
- *  after any args.
+ *  with Quarto parameter comments and have the format "#| ", "# | " or "##|"
+ *  as `quartoArgs`, and strip those lines from the result. Also remove up to
+ *  one empty line after any args.
  */
 export function processQuartoArgs(lines: string[]): {
   lines: string[];
   quartoArgs: QuartoArgs;
 } {
   let i = 0;
+  const rgxQuartoComment = /^(# ?|##)\| /;
   while (i < lines.length) {
     const line = lines[i];
-    if (!line.match(/^#\| /)) {
+    if (!line.match(rgxQuartoComment)) {
       // Remove up to one blank line after finding any args.
       if (line === "") {
         i++;
@@ -114,7 +115,7 @@ export function processQuartoArgs(lines: string[]): {
   // Extract the lines that start with "#| " and remove that comment prefix.
   const argCommentLines = lines
     .slice(0, i)
-    .map((line) => line.replace(/^#\| /, ""));
+    .map((line) => line.replace(rgxQuartoComment, ""));
 
   // Parse the args as YAML.
   const quartoArgs: QuartoArgs = yamlLoad(

--- a/src/parse-codeblock.ts
+++ b/src/parse-codeblock.ts
@@ -88,7 +88,7 @@ export function parseCodeBlock(
 
 /**
  *  Loop through all the lines and extract lines at the beginning which start
- *  with Quarto parameter comments and have the format "#| ", "# | " or "##|"
+ *  with Quarto parameter comments and have the format "#| ", "# | " or "##| "
  *  as `quartoArgs`, and strip those lines from the result. Also remove up to
  *  one empty line after any args.
  */


### PR DESCRIPTION
See https://github.com/quarto-dev/quarto/issues/368 for context.

Both `black` and `ruff format` (and others) add spaces after single `#` starting a comment, so `#|` becomes `# |`. The Quarto VS Code extension supports formatting inside Python code chunks, so in general Quarto also supports `# |` for it's code cell metadata syntax.

<table>
    <tr>
        <th>Before</th>
        <th>Formatted</th>
    </tr>
    <tr>
        <td><pre><code>
#| test: one
# | test: two
##| test: three</code></pre></td>
        <td><pre><code>
# | test: one
# | test: two
##| test: three</code></pre></td>
    </tr>
</table>

In https://github.com/quarto-dev/quarto/issues/368#issuecomment-2596098504 I proposed Quarto also support `##|`, since the formatters don't mess with that. I included support for that here, considering we already use `## file:`.