### PR TITLE
feat: Disable server-side bookmarking for py-shiny

### DIFF
--- a/src/hooks/usePyodide.tsx
+++ b/src/hooks/usePyodide.tsx
@@ -377,8 +377,23 @@ async def _start_app(app_name, scope = _shiny_app_registry, dev_mode = False):
     import os
     import sys
     import importlib
+    import shiny
     import shiny.express
     from pathlib import Path
+
+    if (
+        hasattr(shiny, "bookmark")
+        and hasattr(shiny.bookmark, "set_global_save_dir_fn")
+        and hasattr(shiny.bookmark, "set_global_restore_dir_fn")
+    ):
+
+        def not_configured(id):
+            raise NotImplementedError(
+                "shinylive is not configured to save sessions to disk."
+            )
+
+        shiny.bookmark.set_global_save_dir_fn(not_configured)
+        shiny.bookmark.set_global_restore_dir_fn(not_configured)
 
     app_dir = f"/home/pyodide/{app_name}"
     sys.path.insert(0, app_dir)


### PR DESCRIPTION
Related: https://github.com/posit-dev/py-shiny/issues/1914

Related: https://github.com/posit-dev/py-shiny/issues/1956

--------------

Q: Should [R shiny](https://github.com/posit-dev/shinylive/blob/0ca09681baf8116307e952935c62a3a5ec44452b/src/hooks/useWebR.tsx#L149) also have it's server-side bookmarking disabled?
  * Can R perform server-side bookmarking?

Q: This might get the app to have bookmarking... but what about forwarding any query string values to the parent frame for shinylive.io? If the same answer as r-shiny is... not at the top of the priority queue... then we can wait until later!

TODO:
- [x] Test locally (cc @karangattu )