### PR TITLE
ci: upgrade GitHub Actions to Node.js 24 versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,10 +23,10 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -77,7 +77,7 @@ jobs:
       # =====================================================
       - name: Configure AWS Credentials
         if: github.ref == 'refs/heads/deploy'
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v5
         env:
           AWS_ACCOUNT_ID: "341745101194"
           AWS_REGION: us-east-1

--- a/.github/workflows/update_shiny.yml
+++ b/.github/workflows/update_shiny.yml
@@ -11,9 +11,9 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
## Summary

Upgrades GitHub Actions to current major versions to silence two CI warnings:

- **Node.js 20 deprecation warning** — `actions/checkout`, `actions/setup-python`, and `aws-actions/configure-aws-credentials` are running on Node.js 20, which GitHub will force to Node.js 24 by default starting June 2, 2026.
- **AWS SDK for JavaScript v2 maintenance-mode notice** — emitted by `aws-actions/configure-aws-credentials@v2`. The v5 release migrated to AWS SDK v3.

### Changes

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `v4` | `v5` |
| `actions/setup-python` | `v5` | `v6` |
| `aws-actions/configure-aws-credentials` | `v2` | `v5` |

Applied to both `.github/workflows/build.yml` and `.github/workflows/update_shiny.yml`.

## Verification

Open the Actions run on this PR and confirm the build job logs no longer contain the \`Node.js 20 actions are deprecated\` warning. (The AWS SDK v2 notice only appears on deploy runs, which exercise the \`configure-aws-credentials\` step.)