### PR TITLE
release: v0.10.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shinylive",
-  "version": "0.10.9",
+  "version": "0.10.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shinylive",
-      "version": "0.10.9",
+      "version": "0.10.12",
       "license": "MIT",
       "devDependencies": {
         "@codemirror/autocomplete": "^6.4.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "shinylive",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "Run Shiny applications with R or Python running in the browser.",
   "main": "index.js",
   "repository": {

--- a/shinylive_lock.json
+++ b/shinylive_lock.json
@@ -15,8 +15,8 @@
   },
   "shiny": {
     "name": "shiny",
-    "version": "1.6.2",
-    "filename": "shiny-1.6.2-py3-none-any.whl",
+    "version": "1.6.3",
+    "filename": "shiny-1.6.3-py3-none-any.whl",
     "sha256": null,
     "url": null,
     "depends": [


### PR DESCRIPTION
Bumps the bundled **py-shiny** to **v1.6.3**.

### Changes
- `packages/py-shiny` submodule → v1.6.3
- `shinylive_lock.json` → shiny 1.6.3
- `package.json` → 0.10.12

htmltools 0.7.0 and shinywidgets 0.8.1 were already bundled as of v0.10.11, so no change there. faicons stays at 0.2.2.

### Testing
All 51 local Python examples pass (0 errors) against `make serve` with the rebuilt bundle.

### Known follow-up (not blocking)
shinyswatch remains frozen at **0.8.0** in the bundle (as in all recent releases). Bumping PyPI-sourced deps requires the full `make update_packages_lock` regen, which currently **drops `sniffio`** (and other pyodide-builtin transitive deps like `anyio`), breaking app startup with `ModuleNotFoundError: No module named 'sniffio'`. Worth fixing `scripts/pyodide_packages.py` `generate_lockfile` separately so PyPI deps can be refreshed cleanly.

---
Part of the py-shiny v1.6.3 release train. See posit-dev/py-shiny#2266.