### PR TITLE
Bump bundled shinychat to 0.4.0

### DIFF
--- a/shinylive_lock.json
+++ b/shinylive_lock.json
@@ -567,12 +567,12 @@
   },
   "shinychat": {
     "name": "shinychat",
-    "version": "0.2.8",
-    "filename": "shinychat-0.2.8-py3-none-any.whl",
-    "sha256": "6742a2354257280458269a8b5675f1254e5583be34b6eb1a626de44c0323286a",
-    "url": "https://files.pythonhosted.org/packages/16/01/8658eaffa920f4c621f05acc42ea98248147706079287b3a7ab4e47e1ece/shinychat-0.2.8-py3-none-any.whl",
+    "version": "0.4.0",
+    "filename": "shinychat-0.4.0-py3-none-any.whl",
+    "sha256": "3571b52b26f8a93d7a53a9d85f27207c8d2a081b5443d0b0f918adcc21a01d87",
+    "url": "https://files.pythonhosted.org/packages/9b/1b/05b670402b6d28298c5312e738697c35cf1be5c0f4ccdefa5a55f5710f6b/shinychat-0.4.0-py3-none-any.whl",
     "depends": [
-      {"name": "htmltools", "specs": [[">=", "0.6.0"]]},
+      {"name": "htmltools", "specs": [[">=", "0.7.0"]]},
       {"name": "shiny", "specs": [[">=", "1.4.0"]]}
     ],
     "imports": [

--- a/shinylive_requirements.json
+++ b/shinylive_requirements.json
@@ -2,6 +2,7 @@
   { "name": "htmltools", "source": "local", "version": "latest" },
   { "name": "shiny", "source": "local", "version": "latest" },
   { "name": "shinywidgets", "source": "local", "version": "latest" },
+  { "name": "shinychat", "source": "pypi", "version": "latest" },
   { "name": "shinyswatch", "source": "pypi", "version": "latest" },
   { "name": "faicons", "source": "local", "version": "latest" },
   {


### PR DESCRIPTION
## Why

Shinylive bundled **shinychat 0.2.8** while the latest PyPI release is **0.4.0**, so chat apps in shinylive ran against an old version even after we shipped the latest Shiny for Python. This brings the bundled Shiny Chat current.

The staleness wasn't an oversight in any one release — `shinychat` was never a tracked package. It only entered `shinylive_lock.json` as a *transitive* dependency of `shiny` (`shinychat>=0.1.0`), and the routine local relock (`update_packages_lock_local`) never re-resolves already-present transitive deps. So it froze at the version it first appeared with (0.10.6) and stayed there through every subsequent shiny bump.

## What changed

- `shinylive_lock.json`: update the `shinychat` entry to 0.4.0 (version, filename, sha256, url, and its `htmltools` spec). No other package moves.
- `shinylive_requirements.json`: declare `shinychat` as an explicit PyPI requirement so a full `generate_lockfile` treats it as a first-class package rather than an incidental transitive dep.

No build-script behavior changes.

## Verification

`make retrieve_packages update_pyodide_lock_json` regenerates the pyodide lock cleanly with shinychat 0.4.0 (deps resolve to `htmltools`; `shiny` stripped by the existing circular-dependency hack) and every other package unchanged.

## Note for whoever owns releases

This unsticks shinychat to the current release but does **not** make it auto-refresh on future releases — it will sit at 0.4.0 until a deliberate bump or a full `generate_lockfile`, the same as the other pinned PyPI deps (shinyswatch, plotly, etc.). Making it (and the other pinned deps) track automatically is a larger, separate change to `update_lockfile_local` that needs canonical-name-aware pruning to be done safely, and is best decided with the build-system maintainers.