### PR TITLE
release: v0.10.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shinylive",
-  "version": "0.10.12",
+  "version": "0.10.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shinylive",
-      "version": "0.10.12",
+      "version": "0.10.13",
       "license": "MIT",
       "devDependencies": {
         "@codemirror/autocomplete": "^6.4.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "shinylive",
-  "version": "0.10.12",
+  "version": "0.10.13",
   "description": "Run Shiny applications with R or Python running in the browser.",
   "main": "index.js",
   "repository": {

--- a/shinylive_lock.json
+++ b/shinylive_lock.json
@@ -15,8 +15,8 @@
   },
   "shiny": {
     "name": "shiny",
-    "version": "1.6.3",
-    "filename": "shiny-1.6.3-py3-none-any.whl",
+    "version": "1.6.4",
+    "filename": "shiny-1.6.4-py3-none-any.whl",
     "sha256": null,
     "url": null,
     "depends": [


### PR DESCRIPTION
Bumps the bundled py-shiny to **v1.6.4**.

## Changes

- `packages/py-shiny`: `48b4faa0` (v1.6.3) → `31ea9129` (v1.6.4)
- `package.json` / `package-lock.json`: 0.10.12 → 0.10.13
- `shinylive_lock.json`: `shiny` 1.6.3 → 1.6.4

## Verification

Checked every other Python package submodule against its latest release — all already current, so none needed bumping:

| Package | Pinned | Latest |
|---|---|---|
| py-htmltools | v0.7.0 | v0.7.0 |
| py-shinywidgets | v0.8.1 | v0.8.1 |
| py-faicons | v0.2.2 | v0.2.2 |

`make clean && make all` succeeded. `shinylive_lock.json` diff is exactly the `shiny` version/filename bump.

All 51 Python examples were exercised locally against `make serve` with fresh browser contexts and cache-busting: **51 passed, 0 errors**. `basic_app` was additionally inspected by hand to confirm the app iframe actually renders and executes (slider `N`=20 → `n*2 is 40`).

## Note (pre-existing, not from this PR)

`shinylive_lock.json` pins `shinyswatch` at 0.8.0 while PyPI latest is 0.11.0, even though `shinylive_requirements.json` declares `"version": "latest"`. This was already the case in v0.10.12 and a full `make clean && make all` did not change it, so it is out of scope here — but worth a look separately.