### PR TITLE
chore: Update shinyswatch to v0.11.0

### DIFF
--- a/shinylive_lock.json
+++ b/shinylive_lock.json
@@ -57,15 +57,15 @@
   },
   "shinyswatch": {
     "name": "shinyswatch",
-    "version": "0.8.0",
-    "filename": "shinyswatch-0.8.0-py3-none-any.whl",
-    "sha256": "278a77b23606d988100787100191a8d051566fc281a71786061a5567f2627219",
-    "url": "https://files.pythonhosted.org/packages/53/b7/6f365305aed5ef053cd8228b17b3e5c964c93eb58a68f8fa835e44ab9163/shinyswatch-0.8.0-py3-none-any.whl",
+    "version": "0.11.0",
+    "filename": "shinyswatch-0.11.0-py3-none-any.whl",
+    "sha256": "2c4dd5036d00fe8f8bcd5ed90e8b433cfa64cfcff7b91424a768c0df9cd7e6ed",
+    "url": "https://files.pythonhosted.org/packages/15/c2/7498240c02e46be103e70ad8e938f9898afe8047c4e690b50b7b11140a5c/shinyswatch-0.11.0-py3-none-any.whl",
     "depends": [
       {"name": "typing-extensions", "specs": [[">=", "3.10.0.0"]]},
       {"name": "packaging", "specs": [[">=", "20.9"]]},
       {"name": "htmltools", "specs": [[">=", "0.2.0"]]},
-      {"name": "shiny", "specs": [[">=", "1.2.0"]]}
+      {"name": "shiny", "specs": [[">=", "1.6.3"]]}
     ],
     "imports": [
       "shinyswatch"


### PR DESCRIPTION
Bumps the pinned `shinyswatch` in `shinylive_lock.json` from **0.8.0** (last set in #186, Apr 2023) to **0.11.0**. Follow-up to the note in #230.

Rebased onto `main` after #234; the sole diff against `main` is the one lockfile entry.

## Why it was stale

`shinylive_requirements.json` declares `"version": "latest"`, but that only takes effect during a full `make update_packages_lock`. `make all` runs `update_packages_lock_local`, which filters the requirements down to `source: "local"` and then does `lockfile_info.update(...)` — existing PyPI entries are carried over verbatim and never re-resolved. So `make clean && make all` cannot move this pin; `"latest"` means "latest as of the last full regen", not "always latest".

## Why a targeted edit rather than a regen

A full `make update_packages_lock` is currently broken. It moves 28 packages and produces a lockfile that fails at runtime with `No known package with name 'jupyterlab_widgets'`, breaking every shinywidgets app (Plotly, Map, altair). Root cause and suggested fix are in **#233**.

This therefore changes only the `shinyswatch` entry, generated with the repo's own `_get_pypi_package_info()` so field order and formatting match the rest of the file rather than being hand-typed.

## Verification

Built and driven in a real browser (`make all`, then the editor on `:3000`):

- A shinyswatch app renders with the superhero theme applied — body `rgb(15, 37, 55)`, primary button `rgb(223, 105, 25)` — reporting `v=0.11.0 shiny=1.6.3`, with **0 console errors**.
- Reactivity round-trips over the session: slider 30 → 77 updated the rendered output.
- Regression-checked shinywidgets on this lockfile, since that's what the full regen broke: plotnine image renders 575×400, plotly plot renders, 0 console errors.
- `make all` exits 0, and the lockfile is byte-identical across two runs — the `update_packages_lock_local` pass doesn't disturb this edit.
- Wheels in `build/shinylive/pyodide` match `pyodide-lock.json` exactly: no extras, none missing.

Bundled shiny on this base is 1.6.3, satisfying 0.11.0's `shiny>=1.6.3` — hence the dep spec moving from `>=1.2.0`.

## 0.8.0 was degraded, not just old

Tested in a clean venv against shiny 1.6.3:

- `shinyswatch.theme.superhero()` passed as a positional child raises `SyntaxError: The Theme class is not meant to be used as a standalone HTML tag` — at **0.8.0 as well as 0.11.0**. That's Shiny's `Theme` change rather than a shinyswatch regression, but it means the old usage pattern was already broken before this bump.
- 0.8.0 via `theme=` requires `libsass` to compile Sass at runtime. 0.11.0 rendered with **no libsass installed**, so in shinylive it avoids loading the 452 KB libsass wheel and doing a browser-side Sass compile.

0.11.0 also adds a theme (27 vs 26).

## The bundled example

`examples/python/shinyswatch/` was removed in #234 as one of 23 unreachable example directories. `shinyswatch` remains a supported package for user apps regardless — it's listed in `shinylive_requirements.json`, and `create_typeshed.py` ships its type stubs to the editor's type checker (9 `shinyswatch/*.pyi` entries in the built typeshed). The package pin and the bundled example are independent.