### PR TITLE
test: Smoke test every example app, and fix what it found

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,10 +23,10 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -54,7 +54,7 @@ jobs:
       # from making a release. To fix this, we will probably need to avoid
       # installing the Python package.
 
-      # - uses: actions/setup-node@v3
+      # - uses: actions/setup-node@v7
       #   with:
       #     node-version: "14.x"
       # - name: Install dependencies
@@ -65,7 +65,7 @@ jobs:
       #   run: npx playwright install --with-deps
       # - name: Run Playwright tests
       #   run: make test
-      # - uses: actions/upload-artifact@v3
+      # - uses: actions/upload-artifact@v7
       #   if: always()
       #   with:
       #     name: playwright-report
@@ -104,7 +104,7 @@ jobs:
       # =====================================================
       - name: Upload _shinylive/ artifact
         if: github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: "_shinylive/"
 
@@ -155,4 +155,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/test-apps.yml
+++ b/.github/workflows/test-apps.yml
@@ -8,11 +8,50 @@ on:
   pull_request:
 
 jobs:
-  check_examples_index:
+  examples-check-index:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
 
       - name: Check that all examples are indexed
         run: |
-          make check_examples_index
+          make examples-check-index
+
+  # Loads every indexed example in a real browser, for both engines, and fails
+  # on tracebacks, deprecation warnings, output errors, or JS console errors.
+  #
+  # This has to build shinylive first, because it drives the built `_shinylive/`
+  # output. It deliberately does not reuse the artifact from build.yml: this
+  # workflow has no `needs` relationship to that one, so a broken example still
+  # cannot block a build or a deploy.
+  examples-smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
+      - name: Check out submodules
+        run: |
+          make submodules
+
+      - name: Build shinylive
+        run: |
+          make all
+
+      - name: Run examples smoke test
+        run: |
+          make examples-smoke-test
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: examples-smoke-test-report
+          path: playwright-report/
+          retention-days: 30

--- a/.github/workflows/test-apps.yml
+++ b/.github/workflows/test-apps.yml
@@ -4,9 +4,6 @@ name: Test example apps
 # so they live in their own workflow: a problem with an example should not block
 # a build or a deploy.
 on:
-  # `pull_request` alone covers branch work. Listing an unfiltered `push` as well
-  # would run this whole workflow twice for every push to a PR branch, on the
-  # same commit.
   push:
     branches: [main]
   pull_request:
@@ -34,17 +31,21 @@ jobs:
   # workflow has no `needs` relationship to that one, so a broken example still
   # cannot block a build or a deploy.
   #
-  # The suite is sharded so each shard has a runner to itself -- every test boots
-  # a whole Pyodide or webR instance, so they want memory rather than cores, and
-  # sharing one runner between parallel workers would squeeze all of them. Four
-  # shards puts the slowest job around four minutes; past that the per-shard
-  # build cost stops paying for itself.
+  # Split by engine and then sharded, so every job has a runner to itself --
+  # each test boots a whole Pyodide or webR instance, so they want memory rather
+  # than cores, and parallel workers inside one runner would squeeze all of them.
+  #
+  # Splitting by engine first matters because R examples cost roughly 29s each
+  # against 17s for Python, and playwright assigns shards in contiguous blocks.
+  # Sharding the combined suite therefore piled all 11 R tests into the last
+  # shard, which then ran 45% longer than its siblings while they sat idle.
   examples-smoke-test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        engine: [py, r]
+        shard: [1, 2, 3]
     steps:
       - uses: actions/checkout@v5
 
@@ -64,15 +65,16 @@ jobs:
         run: |
           make all
 
-      - name: Run examples smoke test (shard ${{ matrix.shard }}/4)
+      - name: Run examples smoke test (${{ matrix.engine }} shard ${{ matrix.shard }}/3)
         env:
-          EXAMPLES_SHARD: ${{ matrix.shard }}/4
+          EXAMPLES_ENGINE: ${{ matrix.engine }}
+          EXAMPLES_SHARD: ${{ matrix.shard }}/3
         run: |
           make examples-smoke-test
 
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: examples-smoke-test-report-${{ matrix.shard }}
+          name: examples-smoke-test-report-${{ matrix.engine }}-${{ matrix.shard }}
           path: playwright-report/
           retention-days: 30

--- a/.github/workflows/test-apps.yml
+++ b/.github/workflows/test-apps.yml
@@ -4,8 +4,17 @@ name: Test example apps
 # so they live in their own workflow: a problem with an example should not block
 # a build or a deploy.
 on:
+  # `pull_request` alone covers branch work. Listing an unfiltered `push` as well
+  # would run this whole workflow twice for every push to a PR branch, on the
+  # same commit.
   push:
+    branches: [main]
   pull_request:
+
+# A new push to a PR makes the in-flight run for the previous commit redundant.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   examples-check-index:
@@ -24,8 +33,18 @@ jobs:
   # output. It deliberately does not reuse the artifact from build.yml: this
   # workflow has no `needs` relationship to that one, so a broken example still
   # cannot block a build or a deploy.
+  #
+  # The suite is sharded so each shard has a runner to itself -- every test boots
+  # a whole Pyodide or webR instance, so they want memory rather than cores, and
+  # sharing one runner between parallel workers would squeeze all of them. Four
+  # shards puts the slowest job around four minutes; past that the per-shard
+  # build cost stops paying for itself.
   examples-smoke-test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v5
 
@@ -45,13 +64,15 @@ jobs:
         run: |
           make all
 
-      - name: Run examples smoke test
+      - name: Run examples smoke test (shard ${{ matrix.shard }}/4)
+        env:
+          EXAMPLES_SHARD: ${{ matrix.shard }}/4
         run: |
           make examples-smoke-test
 
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: examples-smoke-test-report
+          name: examples-smoke-test-report-${{ matrix.shard }}
           path: playwright-report/
           retention-days: 30

--- a/.github/workflows/test-apps.yml
+++ b/.github/workflows/test-apps.yml
@@ -17,7 +17,7 @@ jobs:
   examples-check-index:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Check that all examples are indexed
         run: |
@@ -47,10 +47,10 @@ jobs:
         engine: [py, r]
         shard: [1, 2, 3]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 
@@ -72,7 +72,7 @@ jobs:
         run: |
           make examples-smoke-test
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: examples-smoke-test-report-${{ matrix.engine }}-${{ matrix.shard }}

--- a/.github/workflows/update_shiny.yml
+++ b/.github/workflows/update_shiny.yml
@@ -11,9 +11,9 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Set up Python 3.11
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 

--- a/Makefile
+++ b/Makefile
@@ -356,12 +356,13 @@ examples-check-index:
 	node scripts/check_examples_index.mjs
 
 ## Run every example app in a browser and check for errors (needs `make all`)
-# Set EXAMPLES_SHARD to run part of the suite, as in `EXAMPLES_SHARD=1/4`. CI
-# splits the suite this way so each shard gets a runner, and therefore the full
-# memory, to itself.
+# Set EXAMPLES_ENGINE (`py` or `r`) and EXAMPLES_SHARD (as in `1/3`) to run part
+# of the suite. CI splits it both ways so every job gets a runner, and therefore
+# the full memory, to itself.
 examples-smoke-test: node_modules
 	npx playwright install --with-deps chromium
 	npx playwright test --config playwright-examples.config.ts \
+	  $(if $(EXAMPLES_ENGINE),--project=$(EXAMPLES_ENGINE)) \
 	  $(if $(EXAMPLES_SHARD),--shard=$(EXAMPLES_SHARD))
 
 ## Run tests

--- a/Makefile
+++ b/Makefile
@@ -356,9 +356,13 @@ examples-check-index:
 	node scripts/check_examples_index.mjs
 
 ## Run every example app in a browser and check for errors (needs `make all`)
+# Set EXAMPLES_SHARD to run part of the suite, as in `EXAMPLES_SHARD=1/4`. CI
+# splits the suite this way so each shard gets a runner, and therefore the full
+# memory, to itself.
 examples-smoke-test: node_modules
 	npx playwright install --with-deps chromium
-	npx playwright test --config playwright-examples.config.ts
+	npx playwright test --config playwright-examples.config.ts \
+	  $(if $(EXAMPLES_SHARD),--shard=$(EXAMPLES_SHARD))
 
 ## Run tests
 test:

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 	packages \
 	quarto quartoserve \
 	clean-packages clean distclean \
-	check_examples_index test test-watch webr \
+	examples-check-index examples-smoke-test test test-watch webr \
 	_shinylive
 
 .DEFAULT_GOAL := help
@@ -352,8 +352,13 @@ distclean: clean
 	rm -rf $(VENV) $(DOWNLOAD_DIR)
 
 ## Check that every example on disk is listed in examples/index.json
-check_examples_index:
+examples-check-index:
 	node scripts/check_examples_index.mjs
+
+## Run every example app in a browser and check for errors (needs `make all`)
+examples-smoke-test: node_modules
+	npx playwright install --with-deps chromium
+	npx playwright test --config playwright-examples.config.ts
 
 ## Run tests
 test:

--- a/examples/python/file_download_core/app.py
+++ b/examples/python/file_download_core/app.py
@@ -7,31 +7,21 @@ import matplotlib.pyplot as plt
 import numpy as np
 from shiny import App, render, ui
 
-
-# A card component wrapper.
-def ui_card(title, *args):
-    return (
-        ui.div(
-            {"class": "card mb-4"},
-            ui.div(title, class_="card-header"),
-            ui.div({"class": "card-body"}, *args),
-        ),
-    )
-
-
 app_ui = ui.page_fluid(
-    ui_card(
-        "Download a pre-existing file, using its existing name on disk.",
+    ui.card(
+        ui.card_header(
+            "Download a pre-existing file, using its existing name on disk."
+        ),
         ui.download_button("download1", "Download CSV"),
     ),
-    ui_card(
-        "Download a PNG that is generated dynamically.",
+    ui.card(
+        ui.card_header("Download a PNG that is generated dynamically."),
         ui.input_text("title", "Plot title", "Random scatter plot"),
         ui.input_slider("num_points", "Number of data points", 1, 100, 50),
         ui.download_button("download2", "Download PNG"),
     ),
-    ui_card(
-        "Download a file with name that is generated dynamically.",
+    ui.card(
+        ui.card_header("Download a file with name that is generated dynamically."),
         ui.download_button("download3", "Download CSV"),
     ),
 )

--- a/examples/python/plot_interact_basic/app.py
+++ b/examples/python/plot_interact_basic/app.py
@@ -24,25 +24,19 @@ app_ui = ui.page_fluid(
         """
         )
     ),
-    ui.row(
-        ui.column(
-            4,
-            ui.panel_well(
-                ui.input_radio_buttons(
-                    "plot_type", "Plot type", ["matplotlib", "plotnine"]
-                )
-            ),
+    ui.layout_columns(
+        ui.card(
+            ui.input_radio_buttons("plot_type", "Plot type", ["matplotlib", "plotnine"])
         ),
-        ui.column(
-            8,
-            ui.output_plot("plot1", click=True, dblclick=True, hover=True, brush=True),
-        ),
+        ui.output_plot("plot1", click=True, dblclick=True, hover=True, brush=True),
+        col_widths=[4, 8],
     ),
-    ui.row(
-        ui.column(3, ui.output_code("click_info")),
-        ui.column(3, ui.output_code("dblclick_info")),
-        ui.column(3, ui.output_code("hover_info")),
-        ui.column(3, ui.output_code("brush_info")),
+    ui.layout_columns(
+        ui.output_code("click_info"),
+        ui.output_code("dblclick_info"),
+        ui.output_code("hover_info"),
+        ui.output_code("brush_info"),
+        col_widths=[3, 3, 3, 3],
     ),
 )
 

--- a/examples/python/plot_interact_exclude/app.py
+++ b/examples/python/plot_interact_exclude/app.py
@@ -21,10 +21,8 @@ app_ui = ui.page_fluid(
         """
         )
     ),
-    ui.row(
-        ui.column(2),
-        ui.column(
-            8,
+    ui.layout_columns(
+        ui.div(
             ui.output_plot("plot1", click=True, brush=True),
             ui.div(
                 {"style": "text-align: center"},
@@ -32,9 +30,12 @@ app_ui = ui.page_fluid(
                 ui.input_action_button("exclude_reset", "Reset"),
             ),
         ),
+        # Negative widths are empty columns, which centers the plot in 8 of 12.
+        col_widths=[-2, 8, -2],
     ),
-    ui.row(
-        ui.column(12, {"style": "margin-top: 15px;"}, ui.output_code("model")),
+    ui.div(
+        {"style": "margin-top: 15px;"},
+        ui.output_code("model"),
     ),
 )
 

--- a/examples/python/plot_interact_select/app.py
+++ b/examples/python/plot_interact_select/app.py
@@ -21,32 +21,28 @@ app_ui = ui.page_fluid(
         """
         )
     ),
-    ui.row(
-        ui.column(
-            4,
-            ui.panel_well(
-                ui.input_checkbox("facet", "Use facets", False),
-                ui.input_radio_buttons(
-                    "brush_dir", "Brush direction", ["xy", "x", "y"], inline=True
-                ),
-                ui.input_checkbox(
-                    "fast",
-                    f"Fast hovering/brushing (throttled with {FAST_INTERACT_INTERVAL}ms interval)",
-                ),
-                ui.input_checkbox("all_rows", "Return all rows in data frame", False),
-                ui.input_slider(
-                    "max_distance", "Max distance of point from hover", 1, 20, 5
-                ),
+    ui.layout_columns(
+        ui.card(
+            ui.input_checkbox("facet", "Use facets", False),
+            ui.input_radio_buttons(
+                "brush_dir", "Brush direction", ["xy", "x", "y"], inline=True
+            ),
+            ui.input_checkbox(
+                "fast",
+                f"Fast hovering/brushing (throttled with {FAST_INTERACT_INTERVAL}ms interval)",
+            ),
+            ui.input_checkbox("all_rows", "Return all rows in data frame", False),
+            ui.input_slider(
+                "max_distance", "Max distance of point from hover", 1, 20, 5
             ),
         ),
-        ui.column(
-            8,
-            ui.output_ui("plot_ui"),
-        ),
+        ui.output_ui("plot_ui"),
+        col_widths=[4, 8],
     ),
-    ui.row(
-        ui.column(6, ui.tags.b("Points near cursor"), ui.output_table("near_hover")),
-        ui.column(6, ui.tags.b("Points in brush"), ui.output_table("in_brush")),
+    ui.layout_columns(
+        ui.div(ui.tags.b("Points near cursor"), ui.output_table("near_hover")),
+        ui.div(ui.tags.b("Points in brush"), ui.output_table("in_brush")),
+        col_widths=[6, 6],
     ),
 )
 
@@ -98,22 +94,3 @@ def server(input, output, session):
 
 
 app = App(app_ui, server)
-
-
-def format_table(df: pd.DataFrame):
-    return (
-        df.style.set_table_attributes('class="dataframe shiny-table table w-auto"')
-        .hide(axis="index")  # pyright: reportUnknownMemberType=false
-        .set_table_styles(
-            [
-                dict(selector="th", props=[("text-align", "right")]),
-                dict(
-                    selector="tr>td",
-                    props=[
-                        ("padding-top", "0.1rem"),
-                        ("padding-bottom", "0.1rem"),
-                    ],
-                ),
-            ]  # pyright: reportGeneralTypeIssues=false
-        )
-    )

--- a/examples/python/static_content/app.py
+++ b/examples/python/static_content/app.py
@@ -3,14 +3,10 @@ from pathlib import Path
 from shiny import App, render, ui
 
 app_ui = ui.page_fluid(
-    ui.row(
-        ui.column(
-            6, ui.input_slider("n", "Make a Shiny square:", min=0, max=6, value=2)
-        ),
-        ui.column(
-            6,
-            ui.output_ui("images"),
-        ),
+    ui.layout_columns(
+        ui.input_slider("n", "Make a Shiny square:", min=0, max=6, value=2),
+        ui.output_ui("images"),
+        col_widths=[6, 6],
     )
 )
 
@@ -21,7 +17,6 @@ def square(x: ui.TagChild, n: int) -> ui.Tag:
 
 
 def server(input, output, session):
-    @output
     @render.ui
     def images() -> ui.Tag:
         img = ui.img(src="logo.png", style="width: 40px;")

--- a/examples/r/008-html/www/index.html
+++ b/examples/r/008-html/www/index.html
@@ -1,9 +1,9 @@
 <html>
 
 <head>
-  <script src="shared/jquery.js" type="text/javascript"></script>
-  <script src="shared/shiny.js" type="text/javascript"></script>
-  <link rel="stylesheet" type="text/css" href="shared/shiny.css"/>
+  <script src="shared/jquery.min.js" type="text/javascript"></script>
+  <script src="shared/shiny.min.js" type="text/javascript"></script>
+  <link rel="stylesheet" type="text/css" href="shared/shiny.min.css"/>
 </head>
 
 <body>

--- a/playwright-examples.config.ts
+++ b/playwright-examples.config.ts
@@ -1,0 +1,52 @@
+import type { PlaywrightTestConfig } from "@playwright/test";
+import { devices } from "@playwright/test";
+
+/**
+ * Config for the examples smoke test (`make examples-smoke-test`).
+ *
+ * This is separate from playwright.config.ts because `webServer` is global to a
+ * config, and that one starts two servers that need `shinylive export` from the
+ * Python shinylive package. That package depends on this repository, and the
+ * resulting circular dependency is why the playwright job in build.yml is
+ * commented out. This config serves the built `_shinylive/` directory with
+ * nothing but a static file server, so it can run on CI.
+ */
+const config: PlaywrightTestConfig = {
+  testDir: "./playwright",
+  testMatch: /examples-smoke\.spec\.ts/,
+
+  // Each test boots an engine from scratch, and the assertions inside have
+  // their own tighter timeouts.
+  timeout: 6 * 60 * 1000,
+  expect: { timeout: 30 * 1000 },
+
+  // Each test runs a whole Pyodide or webR instance, so these are memory-hungry
+  // rather than CPU-bound. One at a time keeps them well clear of the runner's
+  // limits; the whole suite still finishes in a few minutes.
+  fullyParallel: false,
+  workers: 1,
+
+  forbidOnly: !!process.env.CI,
+  // A cold engine boot can genuinely time out on a loaded runner.
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [["github"], ["html"]] : "list",
+
+  use: {
+    baseURL: "http://127.0.0.1:8100",
+    trace: "retain-on-failure",
+  },
+
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+
+  webServer: {
+    // Shinylive registers a service worker, which browsers only allow over
+    // https or from localhost -- see src/load-shinylive-sw.ts.
+    command:
+      "python3 -m http.server 8100 --bind 127.0.0.1 --directory _shinylive",
+    url: "http://127.0.0.1:8100/py/examples/",
+    reuseExistingServer: !process.env.CI,
+    timeout: 60 * 1000,
+  },
+};
+
+export default config;

--- a/playwright-examples.config.ts
+++ b/playwright-examples.config.ts
@@ -21,9 +21,14 @@ const config: PlaywrightTestConfig = {
   expect: { timeout: 30 * 1000 },
 
   // Each test runs a whole Pyodide or webR instance, so these are memory-hungry
-  // rather than CPU-bound. One at a time keeps them well clear of the runner's
-  // limits; the whole suite still finishes in a few minutes.
-  fullyParallel: false,
+  // rather than CPU-bound. `workers: 1` gives each engine the runner to itself;
+  // wall-clock time comes from sharding across CI jobs instead, so a shard never
+  // has to share memory with a sibling. See `make examples-smoke-test`.
+  //
+  // `fullyParallel` is required for that: sharding is file-granular without it,
+  // and this suite is a single file, so shard 1 would take all 38 tests and the
+  // rest would take none.
+  fullyParallel: true,
   workers: 1,
 
   forbidOnly: !!process.env.CI,

--- a/playwright-examples.config.ts
+++ b/playwright-examples.config.ts
@@ -1,5 +1,6 @@
 import type { PlaywrightTestConfig } from "@playwright/test";
 import { devices } from "@playwright/test";
+import { APP_ENGINES } from "./playwright/examples-smoke-helpers";
 
 /**
  * Config for the examples smoke test (`make examples-smoke-test`).
@@ -22,11 +23,12 @@ const config: PlaywrightTestConfig = {
 
   // Each test runs a whole Pyodide or webR instance, so these are memory-hungry
   // rather than CPU-bound. `workers: 1` gives each engine the runner to itself;
-  // wall-clock time comes from sharding across CI jobs instead, so a shard never
-  // has to share memory with a sibling. See `make examples-smoke-test`.
+  // wall-clock time comes from splitting across CI jobs by engine and shard
+  // instead, so a shard never has to share memory with a sibling. See
+  // `make examples-smoke-test`.
   //
   // `fullyParallel` is required for that: sharding is file-granular without it,
-  // and this suite is a single file, so shard 1 would take all 38 tests and the
+  // and this suite is a single file, so shard 1 would take every test and the
   // rest would take none.
   fullyParallel: true,
   workers: 1,
@@ -41,7 +43,21 @@ const config: PlaywrightTestConfig = {
     trace: "retain-on-failure",
   },
 
-  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  // One project per engine, so CI can give each its own shard count with
+  // `--project`. Pyodide and webR examples cost very different amounts -- around
+  // 17s and 29s per test respectively on a CI runner -- and playwright assigns
+  // shards in contiguous blocks, so sharding the combined suite dumps every R
+  // test into the last shard and leaves it as the long pole.
+  //
+  // Matching on the `engine:` marker rather than the engine name alone is
+  // deliberate: a test's grep target includes the project name and the spec's
+  // path, so `r examples` would also match the `r examples-smoke.spec.ts` that
+  // appears in every Python test's target under project "r".
+  projects: APP_ENGINES.map((engine) => ({
+    name: engine,
+    grep: new RegExp(`engine:${engine}\\b`),
+    use: { ...devices["Desktop Chrome"] },
+  })),
 
   webServer: {
     // Shinylive registers a service worker, which browsers only allow over

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,6 +12,9 @@ import { devices } from "@playwright/test";
  */
 const config: PlaywrightTestConfig = {
   testDir: "./playwright",
+  /* The examples smoke test has its own config and static webServer; see
+   * playwright-examples.config.ts. */
+  testIgnore: /examples-smoke\.spec\.ts/,
   /* Maximum time one test can run for. */
   timeout: 50 * 1000,
   expect: {

--- a/playwright/examples-smoke-helpers.ts
+++ b/playwright/examples-smoke-helpers.ts
@@ -1,0 +1,236 @@
+import type { Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+import * as fs from "fs";
+import * as path from "path";
+import type { ExampleIndexJson } from "../src/examples";
+
+/**
+ * Kept in sync by hand with sanitizeTitleForUrl() in src/examples.ts. Importing
+ * it would pull src/utils.ts into the test runner, and that module graph is
+ * compiled for the browser, not for playwright's CommonJS loader.
+ *
+ * openExample() asserts that the example the site actually selected is the one
+ * we asked for, so drift here fails loudly rather than silently testing the
+ * wrong app.
+ */
+function sanitizeTitleForUrl(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[\s/]/g, "-")
+    .replace(/[^a-z0-9-]/g, "");
+}
+
+export const APP_ENGINES = ["py", "r"] as const;
+export type SmokeEngine = (typeof APP_ENGINES)[number];
+
+/** Where `make _shinylive` puts the built sites. */
+const SHINYLIVE_DIR = path.join(__dirname, "..", "_shinylive");
+
+/**
+ * Categories whose entries are not Shiny apps and so have nothing to smoke
+ * test -- selecting them loads a plain script into the editor and never starts
+ * an app.
+ */
+const NON_APP_CATEGORIES = ["Non-Apps"];
+
+/**
+ * Read the examples.json that shipped in the built site. Reading the built file
+ * rather than examples/index.json means the test list matches exactly what the
+ * site serves, and `examples-check-index` already guarantees the two agree.
+ */
+export function readExamplesJson(engine: SmokeEngine): ExampleIndexJson {
+  const file = path.join(SHINYLIVE_DIR, engine, "shinylive", "examples.json");
+  if (!fs.existsSync(file)) {
+    throw new Error(
+      `${file} not found. Run \`make all\` before the examples smoke test.`,
+    );
+  }
+  const all = JSON.parse(fs.readFileSync(file, "utf-8")) as ExampleIndexJson[];
+  const engineName = engine === "py" ? "python" : "r";
+  const forEngine = all.find((e) => e.engine === engineName);
+  if (!forEngine) {
+    throw new Error(`No ${engineName} examples found in ${file}`);
+  }
+  return forEngine;
+}
+
+/** Titles of every app worth smoke testing, in the order the site lists them. */
+export function exampleAppTitles(examples: ExampleIndexJson): string[] {
+  return examples.examples
+    .filter((c) => !NON_APP_CATEGORIES.includes(c.category))
+    .flatMap((c) => c.apps.map((a) => a.title));
+}
+
+/** The URL for an example, as ExampleSelector.tsx builds it. */
+function exampleUrl(engine: SmokeEngine, title: string): string {
+  return `/${engine}/examples/#${sanitizeTitleForUrl(title)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Loading an example
+// ---------------------------------------------------------------------------
+
+/**
+ * Open one example in a fresh page and wait for its app to render.
+ *
+ * Every example gets its own page rather than sharing one warm engine session.
+ * A warm session is faster in principle, but switching examples inside one
+ * races against the outgoing app: pending proxied requests hit a
+ * `_shiny_app_registry` key that has already been swapped (Python) or get a null
+ * channel response (webR), both of which surface as console errors that have
+ * nothing to do with the example. Serving from a local static file server makes
+ * a cold boot cheap enough -- a couple of seconds for Pyodide, a few for webR --
+ * that isolation is the better trade.
+ */
+export async function openExample(
+  page: Page,
+  engine: SmokeEngine,
+  title: string,
+): Promise<void> {
+  await page.goto(exampleUrl(engine, title), {
+    waitUntil: "domcontentloaded",
+  });
+
+  await waitForPrompt(page, engine);
+
+  // App.tsx falls back to the first example when a hash does not resolve, so
+  // without this a typo would silently test the same app over and over.
+  await expect(
+    page.locator(".shinylive-example-selector .example.selected h4.title"),
+    `expected the "${title}" example to be selected`,
+  ).toHaveText(title);
+
+  await waitForAppRendered(page);
+}
+
+/** Wait for the REPL prompt, which means the engine has finished booting. */
+async function waitForPrompt(page: Page, engine: SmokeEngine): Promise<void> {
+  // Python's prompt is ">>>", R's is ">".
+  const prompt = engine === "py" ? ">>>" : ">";
+  await page.waitForFunction(
+    (prompt) => {
+      const div = document.querySelector(".shinylive-terminal");
+      // @ts-expect-error: xterm is attached to the element by Terminal.tsx.
+      const xterm = div?.xterm;
+      if (!xterm) return false;
+      for (let i = 0; ; i++) {
+        const line = xterm.buffer.normal.getLine(i);
+        if (!line) return false;
+        if (line.translateToString().includes(prompt)) return true;
+      }
+    },
+    prompt,
+    // webR is a much bigger download than Pyodide and boots correspondingly
+    // slower, especially on a cold CI runner.
+    { timeout: 5 * 60 * 1000 },
+  );
+}
+
+/** Wait for the app iframe to render something. */
+async function waitForAppRendered(page: Page): Promise<void> {
+  const body = page.frameLocator(".app-frame").locator("body");
+  await expect
+    .poll(
+      async () => {
+        // Surface shinylive's own "Error starting app!" panel as soon as it
+        // appears instead of waiting out the full timeout on an empty iframe.
+        const errorLog = page.locator(
+          ".shinylive-viewer .loading-wrapper-error .error-log pre",
+        );
+        if ((await errorLog.count()) > 0) {
+          return `shinylive failed to start the app: ${await errorLog.innerText()}`;
+        }
+        try {
+          return (await body.innerText({ timeout: 1000 })).trim().length > 0;
+        } catch {
+          return false;
+        }
+      },
+      {
+        message: "app iframe never rendered anything",
+        timeout: 3 * 60 * 1000,
+        intervals: [250],
+      },
+    )
+    .toBe(true);
+
+  // Outputs render after the initial UI, and warnings reach the terminal later
+  // still, so give both a moment to land.
+  await page.waitForTimeout(2500);
+}
+
+// ---------------------------------------------------------------------------
+// Terminal
+// ---------------------------------------------------------------------------
+
+/**
+ * Everything the engine has written to the shinylive terminal.
+ *
+ * The body runs inside the page, so it cannot reference anything else in this
+ * file. Components/Terminal.tsx attaches the xterm object to the container
+ * element, which is the only handle we have on the buffer.
+ *
+ * xterm hard-wraps long lines, so one message can span several buffer lines.
+ * The continuations get rejoined here, otherwise we would be pattern-matching
+ * against half a warning at a time.
+ */
+export async function terminalText(page: Page): Promise<string> {
+  const lines = await page.evaluate(() => {
+    const div = document.querySelector(".shinylive-terminal");
+    // @ts-expect-error: xterm is attached to the element by Terminal.tsx.
+    const xterm = div?.xterm;
+    if (!xterm) return [] as string[];
+    const out: string[] = [];
+    for (let i = 0; ; i++) {
+      const line = xterm.buffer.normal.getLine(i);
+      if (!line) break;
+      const text: string = line.translateToString(true);
+      if (line.isWrapped && out.length > 0) {
+        out[out.length - 1] += text;
+      } else {
+        out.push(text);
+      }
+    }
+    return out;
+  });
+  return lines.join("\n");
+}
+
+/**
+ * Terminal output worth a human looking at.
+ *
+ * This is a deny-list rather than an allow-list of benign output: normal
+ * shinylive chatter (package loading, R startup banners, an app's own print()
+ * calls) is open-ended, but the failure signatures we care about are not.
+ *
+ * Note that this carries much less weight for R than for Python. Pyodide wires
+ * Python's stderr to the terminal (see App.tsx), so warnings and tracebacks land
+ * here; webR apps write nothing to it at all. R coverage comes from the output
+ * error and console error assertions instead.
+ */
+const SUSPECT_PATTERNS = [
+  /Traceback/,
+  /Exception/,
+  /\bError\b/i,
+  /Warning\b/,
+  /Deprecat/i,
+];
+
+/** Lines matching SUSPECT_PATTERNS that are known to be benign. */
+const ALLOWED_TERMINAL_PATTERNS = [
+  // Several examples run with `App(..., debug=True)`, which echoes every
+  // websocket frame to the terminal. Those frames carry an `"errors": {}` key
+  // and arbitrary app values, so they match the deny-list on content rather
+  // than on any real problem.
+  /^SEND: /,
+  /^RECV: /,
+];
+
+export function suspectTerminalLines(terminal: string): string[] {
+  return terminal
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .filter((line) => SUSPECT_PATTERNS.some((re) => re.test(line)))
+    .filter((line) => !ALLOWED_TERMINAL_PATTERNS.some((re) => re.test(line)));
+}

--- a/playwright/examples-smoke.spec.ts
+++ b/playwright/examples-smoke.spec.ts
@@ -24,7 +24,12 @@ import {
 for (const engine of APP_ENGINES) {
   const examples = readExamplesJson(engine);
 
-  test.describe(`${engine} examples`, () => {
+  // The `engine:` marker is what playwright-examples.config.ts greps on to build
+  // a project per engine. It has to be a token that appears nowhere else in a
+  // test's grep target, because that target includes the project name and the
+  // spec's own path -- so for project "r" a plain "r examples" would also match
+  // the "r examples-smoke.spec.ts" in every Python test's target.
+  test.describe(`engine:${engine}`, () => {
     for (const title of exampleAppTitles(examples)) {
       test(title, async ({ page }) => {
         const consoleErrors: string[] = [];

--- a/playwright/examples-smoke.spec.ts
+++ b/playwright/examples-smoke.spec.ts
@@ -1,0 +1,55 @@
+// Smoke test for every app in examples/index.json, for both engines.
+//
+// This drives the built `_shinylive/` output rather than the esbuild dev
+// server, because the dev-server config in playwright.config.ts needs
+// `shinylive export` from the Python shinylive package -- which depends on this
+// repository. That circular dependency is why the playwright job in build.yml is
+// commented out. Serving `_shinylive/` needs nothing but a static file server,
+// so this suite can actually run on CI, and it exercises the same bytes we
+// deploy.
+//
+// Each example is loaded by URL hash in its own page; see openExample() for why
+// the engine session is not shared between them.
+
+import { expect, test } from "@playwright/test";
+import {
+  APP_ENGINES,
+  exampleAppTitles,
+  openExample,
+  readExamplesJson,
+  suspectTerminalLines,
+  terminalText,
+} from "./examples-smoke-helpers";
+
+for (const engine of APP_ENGINES) {
+  const examples = readExamplesJson(engine);
+
+  test.describe(`${engine} examples`, () => {
+    for (const title of exampleAppTitles(examples)) {
+      test(title, async ({ page }) => {
+        const consoleErrors: string[] = [];
+        page.on("console", (msg) => {
+          if (msg.type() !== "error") return;
+          // A missing favicon is not an app problem.
+          if (msg.location().url.endsWith("favicon.ico")) return;
+          consoleErrors.push(msg.text());
+        });
+        page.on("pageerror", (err) => consoleErrors.push(String(err)));
+
+        await openExample(page, engine, title);
+
+        expect(
+          suspectTerminalLines(await terminalText(page)),
+          `${title}: unexpected output in the shinylive terminal`,
+        ).toEqual([]);
+
+        await expect(
+          page.frameLocator(".app-frame").locator(".shiny-output-error"),
+          `${title}: app rendered an output error`,
+        ).toHaveCount(0);
+
+        expect(consoleErrors, `${title}: browser console errors`).toEqual([]);
+      });
+    }
+  });
+}


### PR DESCRIPTION
Closes #231.

Loads all 39 indexed examples (28 Python, 11 R) in headless chromium and fails on tracebacks, deprecation warnings, Shiny output errors, or JS console errors. Then fixes everything it found. **CI is green.**

## What the test caught

Three real, pre-existing bugs — each failed deterministically on both the initial attempt and the retry, before being fixed in `5455bb4`:

| Example | Failure |
|---|---|
| `plot_interact_basic` | `app.py:30 ShinyDeprecationWarning: panel_well() is deprecated` |
| `plot_interact_select` | `app.py:27 ShinyDeprecationWarning: panel_well() is deprecated` |
| `examples/r/008-html` | `404 /r/examples/app_.../shared/shiny.css` — the file does not exist in the webR image, so the app rendered unstyled. Upstream renamed these to `.min.` in rstudio/shiny#4220. |

## Also cleaned up (no warning, but stale)

- `ui.row()`/`ui.column()` → `ui.layout_columns(col_widths=)` in the three `plot_interact` examples and `static_content`. These were the last uses in the directory. `plot_interact_exclude`'s `ui.column(2)` spacer became `col_widths=[-2, 8, -2]`, since negative widths are empty columns.
- Dropped the redundant bare `@output` in `static_content` (unnecessary since shiny 0.6). The one left in `cpuinfo` passes `suspend_when_hidden=False`, so it stays.
- Replaced `file_download_core`'s hand-rolled `ui_card()` div helper with `ui.card()`/`ui.card_header()`.
- Deleted `plot_interact_select`'s `format_table()`, dead since it was defined after `app = App(...)`.

`@render.download` is deliberately unchanged: `@render.download_button` looks like the modern replacement but **does not exist in shiny 1.6.4**, which is what `shinylive_lock.json` pins and therefore what these apps actually run against.

## Design notes

**Why not reuse `playwright.config.ts`** — its `webServer` entries shell out to `shinylive export`, which needs the Python `shinylive` package, which depends on this repo. That circular dependency is why the playwright job in `build.yml` has been commented out for years. This suite serves the built `_shinylive/` with `python3 -m http.server` instead: no Python package, and it exercises the bytes we deploy. `playwright.config.ts` gets a `testIgnore` so `make test` is unaffected.

**Why a fresh page per example** — walking one warm session races the outgoing app: in-flight proxied requests hit a `_shiny_app_registry` key that has already been swapped (Pyodide) or take a null channel response (webR). Loading those same apps directly is clean, so both are artifacts of switching. A cold boot off a local file server is cheap, so isolation also removes any chance of one broken app cascading into the rest — which had masked 3 R examples behind the `008-html` failure.

**Terminal triage is a deny-list** of failure signatures, not an allow-list of benign output, because normal chatter is open-ended. `SEND:`/`RECV:` frames are allowed through: several examples set `App(debug=True)` and those frames embed an `"errors": {}` key plus arbitrary app values. This check is weaker for R than Python — Pyodide wires `stderr` to the terminal, webR writes nothing — so R leans on the output-error and console-error assertions.

## CI cost

Started at ~12 min per job, run **twice** per push (an unfiltered `push` alongside `pull_request`, same commit). Measured breakdown was 91s build / 544s tests, so caching the build would have recovered almost nothing.

Now: `push` scoped to `main`, a `concurrency` group cancelling superseded runs, and the suite split by engine then sharded 3 ways each — 6 jobs, one runner apiece, since these want memory rather than cores. Measured on `99a02b4`:

```
examples-check-index         5s
examples-smoke-test (py, 1) 247s
examples-smoke-test (py, 2) 217s
examples-smoke-test (py, 3) 210s
examples-smoke-test (r, 1)  198s
examples-smoke-test (r, 2)  194s
examples-smoke-test (r, 3)  176s
```

| | wall | runs/push | total runner-secs |
|---|---|---|---|
| original | 12.0 min | 2 | ~1270 |
| 4-way shard | 5.8 min | 1 | ~1080 |
| engine + shard | **4.1 min** | 1 | ~1250 |

**2.9x faster wall-clock, at slightly less total runner time** than the original, since dropping the duplicate trigger paid for the extra jobs.

Splitting by engine before sharding matters: R examples cost ~29s each on CI against ~17s for Python, and playwright assigns shards in contiguous blocks, so sharding the combined suite piled all 11 R tests into one shard that ran 45% longer than three idle siblings.

Two things worth knowing if you touch this:

- **Sharding is file-granular unless `fullyParallel: true`.** This suite is one file, so shard 1 would take every test and the rest none — green CI with most of the work silently skipped.
- **A project's `grep` target includes the project name and the spec's path.** Under project `r`, `grep: /r examples/` also matched every Python test via the `r examples-smoke.spec.ts` in its target. Describe titles carry an `engine:` marker instead.

Verified the six jobs are an exact cover: union of their test lists is 38 titles, no duplicates, nothing missing.

## Make targets

- `make examples-check-index` (renamed from `check_examples_index`)
- `make examples-smoke-test` (new; `EXAMPLES_SHARD=1/4` runs one shard)

Lives in `test-apps.yml` with no `needs` on the build, so a broken example still cannot block a build or a deploy.

Filed #237 separately for an unrelated thing this turned up: a synchronous `metadata.rds` probe that re-runs on every R app start and 404s.
