### PR TITLE
release: v0.10.14

### DIFF
--- a/examples/python/file_download_core/app.py
+++ b/examples/python/file_download_core/app.py
@@ -28,19 +28,20 @@ app_ui = ui.page_fluid(
 
 
 def server(input, output, session):
-    @render.download()
+    @render.download_button()
     def download1():
         # This is the simplest case. The implementation simply returns the path to a
         # file on disk.
         path = Path(__file__).parent / "mtcars.csv"
         return str(path)
 
-    @render.download(filename="image.png")
+    @render.download_button(filename="image.png")
     def download2():
         # Another way to implement a file download is by yielding bytes; either all at
         # once, like in this case, or by yielding multiple times. When using this
-        # approach, you should pass a filename argument to @render.download, which
-        # determines what the browser will name the downloaded file.
+        # approach, you should pass a filename argument to
+        # @render.download_button, which determines what the browser will name the
+        # downloaded file.
         x = np.random.uniform(size=input.num_points())
         y = np.random.uniform(size=input.num_points())
         plt.figure()
@@ -50,7 +51,7 @@ def server(input, output, session):
             plt.savefig(buf, format="png")
             yield buf.getvalue()
 
-    @render.download(
+    @render.download_button(
         filename=lambda: f"data-{date.today().isoformat()}-{np.random.randint(100,999)}.csv"
     )
     async def download3():

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shinylive",
-  "version": "0.10.13",
+  "version": "0.10.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shinylive",
-      "version": "0.10.13",
+      "version": "0.10.14",
       "license": "MIT",
       "devDependencies": {
         "@codemirror/autocomplete": "^6.4.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "shinylive",
-  "version": "0.10.13",
+  "version": "0.10.14",
   "description": "Run Shiny applications with R or Python running in the browser.",
   "main": "index.js",
   "repository": {

--- a/shinylive_lock.json
+++ b/shinylive_lock.json
@@ -15,13 +15,13 @@
   },
   "shiny": {
     "name": "shiny",
-    "version": "1.6.4",
-    "filename": "shiny-1.6.4-py3-none-any.whl",
+    "version": "1.7.0",
+    "filename": "shiny-1.7.0-py3-none-any.whl",
     "sha256": null,
     "url": null,
     "depends": [
       {"name": "typing-extensions", "specs": [[">=", "4.10.0"]]},
-      {"name": "starlette", "specs": []},
+      {"name": "starlette", "specs": [[">=", "0.17.1"]]},
       {"name": "htmltools", "specs": [[">=", "0.7.0"]]},
       {"name": "markdown-it-py", "specs": [[">=", "1.1.0"]]},
       {"name": "mdit-py-plugins", "specs": [[">=", "0.3.0"]]},
@@ -32,7 +32,7 @@
       {"name": "narwhals", "specs": [[">=", "1.10.0"]]},
       {"name": "orjson", "specs": [[">=", "3.10.7"]]},
       {"name": "shinychat", "specs": [[">=", "0.1.0"]]},
-      {"name": "opentelemetry-api", "specs": [[">=", "1.20.0"]]}
+      {"name": "opentelemetry-api", "specs": [[">=", "1.24.0"]]}
     ],
     "imports": [
       "shiny"
@@ -57,15 +57,15 @@
   },
   "shinyswatch": {
     "name": "shinyswatch",
-    "version": "0.11.0",
-    "filename": "shinyswatch-0.11.0-py3-none-any.whl",
-    "sha256": "2c4dd5036d00fe8f8bcd5ed90e8b433cfa64cfcff7b91424a768c0df9cd7e6ed",
-    "url": "https://files.pythonhosted.org/packages/15/c2/7498240c02e46be103e70ad8e938f9898afe8047c4e690b50b7b11140a5c/shinyswatch-0.11.0-py3-none-any.whl",
+    "version": "0.12.0",
+    "filename": "shinyswatch-0.12.0-py3-none-any.whl",
+    "sha256": "3b37fadbbf353e7c234c2d0972ba0ea90784559aca37d1e17a4c977fece036e9",
+    "url": "https://files.pythonhosted.org/packages/37/e6/f72496868dd078403ad3a7b8ad61f292149522877fdccb5007d66346ac0e/shinyswatch-0.12.0-py3-none-any.whl",
     "depends": [
       {"name": "typing-extensions", "specs": [[">=", "3.10.0.0"]]},
       {"name": "packaging", "specs": [[">=", "20.9"]]},
       {"name": "htmltools", "specs": [[">=", "0.2.0"]]},
-      {"name": "shiny", "specs": [[">=", "1.6.3"]]}
+      {"name": "shiny", "specs": [[">=", "1.7.0"]]}
     ],
     "imports": [
       "shinyswatch"


### PR DESCRIPTION
Release prep for **shinylive v0.10.14** — the bundle that ships alongside the [py-shiny v1.7.0](https://github.com/posit-dev/py-shiny/releases/tag/v1.7.0) release train. Assets only, no logic changes.

## Submodule bumps

- py-shiny → **v1.7.0**

py-htmltools (v0.7.0), py-shinywidgets (v0.8.1) and py-faicons (v0.2.2) were already at their latest releases.

## Package pin bumps

- shinyswatch **0.11.0 → 0.12.0**

[py-shinyswatch v0.12.0](https://github.com/posit-dev/py-shinyswatch/releases/tag/v0.12.0) regenerated its pre-built themes against shiny 1.7.0, so this pin is what carries the new Bootstrap Offcanvas styles (behind `ui.offcanvas()`) and the sidebar resize-handle fixes into shinylive's bundled themes. Without it the themes would render `ui.offcanvas()` unstyled.

Edited by hand for the reasons #235 established: `make all` runs `update_packages_lock_local`, which filters the requirements to `source: "local"` and carries PyPI entries over verbatim, so `"version": "latest"` cannot move this pin; and a full `make update_packages_lock` is still broken per #233. Generated with the repo's own `_get_pypi_package_info()` so field order and formatting match — which also pulled the raised `shiny>=1.7.0` dep spec automatically rather than my hand-typing it.

## `shinylive_lock.json` after `make clean && make all`

| Package | Before | After |
|---|---|---|
| shiny | 1.6.4 | **1.7.0** |
| shinyswatch | 0.11.0 | **0.12.0** |
| htmltools | 0.7.0 | 0.7.0 |
| shinywidgets | 0.8.1 | 0.8.1 |
| faicons | 0.2.2 | 0.2.2 |

The shiny entry's dep specs were re-derived from the 1.7.0 wheel and picked up that release's raised lower bounds (`starlette>=0.17.1`, `opentelemetry-api>=1.24.0`, from py-shiny#2335). The hand-edited shinyswatch entry survived the local pass untouched.

## Verification

`make clean && make all` — built wheels all at the expected versions:

```
shiny-1.7.0-py3-none-any.whl          3.8M
shinyswatch-0.12.0-py3-none-any.whl   1.4M
htmltools-0.7.0-py3-none-any.whl      87.5K
shinywidgets-0.8.1-py3-none-any.whl   1.7M
faicons-0.2.2-py3-none-any.whl        593.0K
```

`examples.json`: 28 Python apps, 11 R apps — matching `examples/index.json`.

**All 28 Python examples pass locally** (`make serve`, fresh browser context per example, cache-busting query param, checking console errors and Python tracebacks):

```
Site: http://localhost:3000/examples/
Results: 28 passed, 0 errors out of 28 examples
```

## Note

`build/shinylive/pyodide` contains two wheels not referenced by `pyodide-lock.json` (`anyio-4.9.0`, `narwhals-1.41.0`). These are pyodide's own upstream versions, which shinylive's older pins (4.4.0, 1.12.1) override in the merged lock — both land on disk, only the pinned ones load. Pre-existing and unrelated to this bump; noting it because #235 reported an exact match.

## Deploy plan

Per the release checklist, after merge and tag: verify github.io with a cache-busted example sweep first, and only then push `main:deploy` for shinylive.io, re-verifying there.