### PR TITLE
feat: Add explanatory loader text is during first load and handle potential loading failure modes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,10 @@ jobs:
       # the build produced above. They run here rather than in test-apps.yml
       # because that build is what they test, and a failure should stop the
       # deploy that follows.
+      #
+      # `make test-site` selects `-m "site and not loader"`. The loader tests are
+      # the other half of that pair and run in the test-loader job below, not
+      # here -- see that job's comment for why.
       - name: Run site and static export tests
         run: |
           make test-site
@@ -196,6 +200,59 @@ jobs:
   # =====================================================
   # Deploy GitHub Pages site
   # =====================================================
+  # The loader's status text and failure modes, against a build of its own.
+  #
+  # Deliberately NOT in the `build` job, and so deliberately not gating the
+  # deploy that job performs. Two reasons, both worth revisiting later:
+  #
+  #  - These tests cost about as much as every other site test put together
+  #    (~59s against ~55s, measured locally), because nearly all of them boot a
+  #    real Pyodide or webR instance and one delays the load on purpose. Paying
+  #    that serially in front of an S3 deploy buys little when it can run
+  #    alongside instead.
+  #  - They are new and have never run on a CI runner. Gating releases on
+  #    engine-booting browser tests with no CI history is how a flaky test turns
+  #    into a stuck release. Once they have a few green runs behind them, moving
+  #    the gate is a one-line change: give this job a `needs:` relationship, or
+  #    fold the marker back into `make test-site`.
+  #
+  # It builds its own copy rather than reusing the build job's output, because
+  # `make all` costs about 90s -- cheaper than restructuring the deploy steps out
+  # of the build job so an artifact could be passed between them.
+  test-loader:
+    name: Loader tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
+      - name: Check out submodules
+        run: |
+          make submodules
+
+      - name: Build shinylive
+        run: |
+          make all
+
+      - name: Run the loader status tests
+        run: |
+          make test-loader
+
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: test-loader-report
+          path: test-results/
+          retention-days: 30
+
   deploy-gh-pages:
     if: github.ref == 'refs/heads/main'
     needs: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,10 +119,8 @@ jobs:
       # because that build is what they test, and a failure should stop the
       # deploy that follows.
       #
-      # `make test-site` selects `-m "site and not loader"`. The loader tests are
-      # the other half of that pair and run in test-loader.yml instead, because
-      # they are slow and should not sit in front of a deploy -- that file's
-      # header explains the trade, and why these tests do not make it.
+      # `make test-site` is `-m "site and not loader"`; the loader half runs in
+      # test-loader.yml.
       - name: Run site and static export tests
         run: |
           make test-site

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,8 +120,9 @@ jobs:
       # deploy that follows.
       #
       # `make test-site` selects `-m "site and not loader"`. The loader tests are
-      # the other half of that pair and run in the test-loader job below, not
-      # here -- see that job's comment for why.
+      # the other half of that pair and run in test-loader.yml instead, because
+      # they are slow and should not sit in front of a deploy -- that file's
+      # header explains the trade, and why these tests do not make it.
       - name: Run site and static export tests
         run: |
           make test-site
@@ -200,59 +201,6 @@ jobs:
   # =====================================================
   # Deploy GitHub Pages site
   # =====================================================
-  # The loader's status text and failure modes, against a build of its own.
-  #
-  # Deliberately NOT in the `build` job, and so deliberately not gating the
-  # deploy that job performs. Two reasons, both worth revisiting later:
-  #
-  #  - These tests cost about as much as every other site test put together
-  #    (~59s against ~55s, measured locally), because nearly all of them boot a
-  #    real Pyodide or webR instance and one delays the load on purpose. Paying
-  #    that serially in front of an S3 deploy buys little when it can run
-  #    alongside instead.
-  #  - They are new and have never run on a CI runner. Gating releases on
-  #    engine-booting browser tests with no CI history is how a flaky test turns
-  #    into a stuck release. Once they have a few green runs behind them, moving
-  #    the gate is a one-line change: give this job a `needs:` relationship, or
-  #    fold the marker back into `make test-site`.
-  #
-  # It builds its own copy rather than reusing the build job's output, because
-  # `make all` costs about 90s -- cheaper than restructuring the deploy steps out
-  # of the build job so an artifact could be passed between them.
-  test-loader:
-    name: Loader tests
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Set up Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: "3.11"
-
-      - name: Upgrade pip
-        run: python -m pip install --upgrade pip
-
-      - name: Check out submodules
-        run: |
-          make submodules
-
-      - name: Build shinylive
-        run: |
-          make all
-
-      - name: Run the loader status tests
-        run: |
-          make test-loader
-
-      - uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: test-loader-report
-          path: test-results/
-          retention-days: 30
-
   deploy-gh-pages:
     if: github.ref == 'refs/heads/main'
     needs: build

--- a/.github/workflows/test-loader.yml
+++ b/.github/workflows/test-loader.yml
@@ -1,22 +1,12 @@
 name: Test the loader
 
-# The loader's status text and its failure modes, in a browser, against a real
-# build. These live in their own workflow rather than in build.yml, for the same
-# reason the example tests do: they are slow, and they should not sit in front of
-# a deploy.
-#
-# They are the `loader` half of the `site` marker. The other half -- the editor,
-# apps loaded from the URL, and static export -- stays in build.yml on purpose,
-# because a failure there should stop the deploy that follows it. That trade is
-# not made here: nearly every test in this workflow boots a real Pyodide or webR
-# instance, so the suite costs about as much as all the other site tests put
-# together, and it has little CI history yet. Gating releases on engine-booting
-# browser tests before knowing how they behave on a runner is how a flaky test
-# becomes a stuck release.
-#
-# Revisit once there is green history. Gating means either moving these tests
-# back under `make test-site`, or triggering the deploy from this workflow's
-# success with `workflow_run`.
+# The loader's status text and failure modes, in a browser. Their own workflow for
+# the same reason the example tests have one: nearly every test boots a real
+# Pyodide or webR instance, so they are slow and should not sit in front of a
+# deploy. They are the `loader` half of the `site` marker; the other half stays in
+# build.yml and still gates the deploy. To gate these too, fold the marker back
+# into `make test-site`, or trigger the deploy from this workflow with
+# `workflow_run`.
 on:
   push:
     branches: [main]
@@ -28,9 +18,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Builds its own copy of the site rather than reusing build.yml's output.
-  # `make all` costs about 90s, which is cheaper than restructuring the deploy
-  # steps out of that workflow's build job so an artifact could be handed over.
+  # Builds its own copy rather than reusing build.yml's: `make all` is cheaper
+  # than moving that workflow's deploy steps out so an artifact could be shared.
   test-loader:
     name: Loader tests
     runs-on: ubuntu-latest

--- a/.github/workflows/test-loader.yml
+++ b/.github/workflows/test-loader.yml
@@ -1,12 +1,6 @@
 name: Test the loader
 
-# The loader's status text and failure modes, in a browser. Their own workflow for
-# the same reason the example tests have one: nearly every test boots a real
-# Pyodide or webR instance, so they are slow and should not sit in front of a
-# deploy. They are the `loader` half of the `site` marker; the other half stays in
-# build.yml and still gates the deploy. To gate these too, fold the marker back
-# into `make test-site`, or trigger the deploy from this workflow with
-# `workflow_run`.
+# Tests the loader's status text and failure modes using playwright.
 on:
   push:
     branches: [main]

--- a/.github/workflows/test-loader.yml
+++ b/.github/workflows/test-loader.yml
@@ -1,0 +1,66 @@
+name: Test the loader
+
+# The loader's status text and its failure modes, in a browser, against a real
+# build. These live in their own workflow rather than in build.yml, for the same
+# reason the example tests do: they are slow, and they should not sit in front of
+# a deploy.
+#
+# They are the `loader` half of the `site` marker. The other half -- the editor,
+# apps loaded from the URL, and static export -- stays in build.yml on purpose,
+# because a failure there should stop the deploy that follows it. That trade is
+# not made here: nearly every test in this workflow boots a real Pyodide or webR
+# instance, so the suite costs about as much as all the other site tests put
+# together, and it has little CI history yet. Gating releases on engine-booting
+# browser tests before knowing how they behave on a runner is how a flaky test
+# becomes a stuck release.
+#
+# Revisit once there is green history. Gating means either moving these tests
+# back under `make test-site`, or triggering the deploy from this workflow's
+# success with `workflow_run`.
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# A new push to a PR makes the in-flight run for the previous commit redundant.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Builds its own copy of the site rather than reusing build.yml's output.
+  # `make all` costs about 90s, which is cheaper than restructuring the deploy
+  # steps out of that workflow's build job so an artifact could be handed over.
+  test-loader:
+    name: Loader tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
+      - name: Check out submodules
+        run: |
+          make submodules
+
+      - name: Build shinylive
+        run: |
+          make all
+
+      - name: Run the loader status tests
+        run: |
+          make test-loader
+
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: test-loader-report
+          path: test-results/
+          retention-days: 30

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 	clean-packages clean distclean \
 	examples-check-index type-check \
 	test-deps test-unit test-unit-coverage \
-	test-examples-smoke test-examples-intent test-site webr \
+	test-examples-smoke test-examples-intent test-site test-loader webr \
 	_shinylive
 
 .DEFAULT_GOAL := help
@@ -407,6 +407,19 @@ test-examples-intent: test-deps
 # apps loaded from the URL, and a static export assembled from build/ by
 # tests/export_app.py. There is one engine's worth of work here, so they run in a
 # single job rather than the examples' engine x shard matrix.
+#
+# This and `test-loader` are halves of a pair: every test in tests/ marked `site`
+# is in exactly one of them. The loader tests are split out because they boot an
+# engine per test and cost about as much as all the other site tests together, so
+# they get their own CI job rather than sitting in the one that deploys. Running
+# both covers the whole `site` marker.
 ## Run the site and static export tests (needs `make all`)
 test-site: test-deps
-	$(PYBIN)/pytest tests -m site $(if $(CI),--reruns 1)
+	$(PYBIN)/pytest tests -m "site and not loader" $(if $(CI),--reruns 1)
+
+# The other half of the pair above. Slow by nature: most of these load a real
+# engine, and one deliberately delays the load so the loader has stages to
+# report. See "Watching a loader test by hand" in tests/README.md.
+## Run the loader status and failure-mode tests (needs `make all`)
+test-loader: test-deps
+	$(PYBIN)/pytest tests -m loader $(if $(CI),--reruns 1)

--- a/pytest.ini
+++ b/pytest.ini
@@ -15,5 +15,6 @@ markers =
     py: an example app running on Pyodide
     r: an example app running on webR
     allow_page_errors: a test that provokes page errors on purpose
+    loader: a loader-status test; slow, and separable from the other site tests
 
 addopts = --browser chromium --tracing retain-on-failure --output test-results

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,3 +8,6 @@ pytest-playwright>=0.5
 pytest-rerunfailures>=14.0
 pytest-timeout>=2.3
 pytest-xdist>=3.5
+
+# Builds the LZ-compressed app hashes the loader tests load apps through.
+lzstring

--- a/src/Components/App.tsx
+++ b/src/Components/App.tsx
@@ -141,9 +141,8 @@ function ensurePyodideProxyHandlePromise({
     pyodideProxyHandlePromise = (async (): Promise<PyodideProxyHandle> => {
       let pyodideProxyHandle: PyodideProxyHandle;
 
-      // Ensure that pyodide and shiny can be successfully initialized
-      // to determine if the engine is usable. If not, set the status state
-      // to "failed" to report the error to the user
+      // Ensure pyodide engine and shiny can be successfully initialized
+      // If not, set the status to "failed" to report the error to the user
       try {
         pyodideProxyHandle = await initPyodide({
           proxyType,
@@ -164,9 +163,9 @@ function ensurePyodideProxyHandlePromise({
 
       if (!pyodideProxyHandle.initError) {
         try {
-          // This block is purely cosmetic and the engine runs whether or not these
-          // succeed, so a throw here must not reach the catch above,
-          // which would be recorded as an engine load failure
+          // This section for printing the terminal console banner is cosmetic only
+          // and logs any errors to the browser console, rather than marking the engine
+          // load as failed "failed".
           terminalInterface.clear();
 
           if (showStartBanner) {

--- a/src/Components/App.tsx
+++ b/src/Components/App.tsx
@@ -11,6 +11,7 @@ import { initPyodide, initShiny, usePyodide } from "../hooks/usePyodide";
 import { useRunOnceOnMount } from "../hooks/useRunOnceOnMount";
 import type { WebRProxyHandle } from "../hooks/useWebR";
 import { initRShiny, initWebR, useWebR } from "../hooks/useWebR";
+import { loadStatusStore } from "../load-status";
 import type { ProxyType } from "../pyodide-proxy";
 import "./App.css";
 import { type EditorMethods } from "./Editor";
@@ -138,30 +139,38 @@ function ensurePyodideProxyHandlePromise({
 }): Promise<PyodideProxyHandle> {
   if (!pyodideProxyHandlePromise) {
     pyodideProxyHandlePromise = (async (): Promise<PyodideProxyHandle> => {
-      let pyodideProxyHandle = await initPyodide({
-        proxyType,
-        stdout: terminalInterface.echo,
-        stderr: terminalInterface.error,
-      });
+      try {
+        let pyodideProxyHandle = await initPyodide({
+          proxyType,
+          stdout: terminalInterface.echo,
+          stderr: terminalInterface.error,
+        });
 
-      if (shiny) {
-        pyodideProxyHandle = await initShiny({ pyodideProxyHandle });
-      }
+        if (shiny) {
+          pyodideProxyHandle = await initShiny({ pyodideProxyHandle });
+        }
 
-      if (!pyodideProxyHandle.initError) {
-        terminalInterface.clear();
+        if (!pyodideProxyHandle.initError) {
+          terminalInterface.clear();
 
-        if (showStartBanner) {
-          // When we get here, .ready will always be true.
-          if (pyodideProxyHandle.ready) {
-            await pyodideProxyHandle.pyodide.runPyAsync(
-              `print(pyodide.console.BANNER); print(" ")`,
-            );
+          if (showStartBanner) {
+            // When we get here, .ready will always be true.
+            if (pyodideProxyHandle.ready) {
+              await pyodideProxyHandle.pyodide.runPyAsync(
+                `print(pyodide.console.BANNER); print(" ")`,
+              );
+            }
           }
         }
-      }
 
-      return pyodideProxyHandle;
+        return pyodideProxyHandle;
+      } catch (e) {
+        loadStatusStore("python").set(
+          "failed",
+          e instanceof Error ? e.message : String(e),
+        );
+        throw e;
+      }
     })();
   }
   return pyodideProxyHandlePromise;
@@ -174,20 +183,28 @@ function ensureWebRProxyHandlePromise({
 }): Promise<WebRProxyHandle> {
   if (!webRProxyHandlePromise) {
     webRProxyHandlePromise = (async (): Promise<WebRProxyHandle> => {
-      let webRProxyHandle = await initWebR({
-        stdout: terminalInterface.echo,
-        stderr: terminalInterface.error,
-      });
+      try {
+        let webRProxyHandle = await initWebR({
+          stdout: terminalInterface.echo,
+          stderr: terminalInterface.error,
+        });
 
-      if (shiny) {
-        webRProxyHandle = await initRShiny({ webRProxyHandle });
+        if (shiny) {
+          webRProxyHandle = await initRShiny({ webRProxyHandle });
+        }
+
+        if (!webRProxyHandle.initError) {
+          terminalInterface.clear();
+        }
+
+        return webRProxyHandle;
+      } catch (e) {
+        loadStatusStore("r").set(
+          "failed",
+          e instanceof Error ? e.message : String(e),
+        );
+        throw e;
       }
-
-      if (!webRProxyHandle.initError) {
-        terminalInterface.clear();
-      }
-
-      return webRProxyHandle;
     })();
   }
   return webRProxyHandlePromise as Promise<WebRProxyHandle>;
@@ -432,6 +449,7 @@ export function App({
             setViewerMethods={setViewerMethods}
             devMode={true}
             setWindowTitle={appOptions.setWindowTitle}
+            engine={appEngine}
           />
         </ResizableGrid>
       </>
@@ -483,6 +501,7 @@ export function App({
             setViewerMethods={setViewerMethods}
             devMode={true}
             setWindowTitle={appOptions.setWindowTitle}
+            engine={appEngine}
           />
         </ResizableGrid>
       </>
@@ -588,6 +607,7 @@ export function App({
           setViewerMethods={setViewerMethods}
           devMode={true}
           setWindowTitle={appOptions.setWindowTitle}
+          engine={appEngine}
         />
       </ResizableGrid>
     );
@@ -611,6 +631,7 @@ export function App({
             setViewerMethods={setViewerMethods}
             devMode={false}
             setWindowTitle={appOptions.setWindowTitle}
+            engine={appEngine}
           />
         </div>
       </>

--- a/src/Components/App.tsx
+++ b/src/Components/App.tsx
@@ -139,8 +139,13 @@ function ensurePyodideProxyHandlePromise({
 }): Promise<PyodideProxyHandle> {
   if (!pyodideProxyHandlePromise) {
     pyodideProxyHandlePromise = (async (): Promise<PyodideProxyHandle> => {
+      let pyodideProxyHandle: PyodideProxyHandle;
+
+      // Ensure that pyodide and shiny can be successfully initialized
+      // to determine if the engine is usable. If not, set the status state
+      // to "failed" to report the error to the user
       try {
-        let pyodideProxyHandle = await initPyodide({
+        pyodideProxyHandle = await initPyodide({
           proxyType,
           stdout: terminalInterface.echo,
           stderr: terminalInterface.error,
@@ -149,8 +154,19 @@ function ensurePyodideProxyHandlePromise({
         if (shiny) {
           pyodideProxyHandle = await initShiny({ pyodideProxyHandle });
         }
+      } catch (e) {
+        loadStatusStore("python").set(
+          "failed",
+          e instanceof Error ? e.message : String(e),
+        );
+        throw e;
+      }
 
-        if (!pyodideProxyHandle.initError) {
+      if (!pyodideProxyHandle.initError) {
+        try {
+          // This block is purely cosmetic and the engine runs whether or not these
+          // succeed, so a throw here must not reach the catch above,
+          // which would be recorded as an engine load failure
           terminalInterface.clear();
 
           if (showStartBanner) {
@@ -161,16 +177,12 @@ function ensurePyodideProxyHandlePromise({
               );
             }
           }
+        } catch (e) {
+          console.error(e);
         }
-
-        return pyodideProxyHandle;
-      } catch (e) {
-        loadStatusStore("python").set(
-          "failed",
-          e instanceof Error ? e.message : String(e),
-        );
-        throw e;
       }
+
+      return pyodideProxyHandle;
     })();
   }
   return pyodideProxyHandlePromise;
@@ -183,8 +195,12 @@ function ensureWebRProxyHandlePromise({
 }): Promise<WebRProxyHandle> {
   if (!webRProxyHandlePromise) {
     webRProxyHandlePromise = (async (): Promise<WebRProxyHandle> => {
+      let webRProxyHandle: WebRProxyHandle;
+
+      // See the note in ensurePyodideProxyHandlePromise: only engine readiness
+      // belongs in here, because "failed" is terminal.
       try {
-        let webRProxyHandle = await initWebR({
+        webRProxyHandle = await initWebR({
           stdout: terminalInterface.echo,
           stderr: terminalInterface.error,
         });
@@ -192,12 +208,6 @@ function ensureWebRProxyHandlePromise({
         if (shiny) {
           webRProxyHandle = await initRShiny({ webRProxyHandle });
         }
-
-        if (!webRProxyHandle.initError) {
-          terminalInterface.clear();
-        }
-
-        return webRProxyHandle;
       } catch (e) {
         loadStatusStore("r").set(
           "failed",
@@ -205,6 +215,16 @@ function ensureWebRProxyHandlePromise({
         );
         throw e;
       }
+
+      if (!webRProxyHandle.initError) {
+        try {
+          terminalInterface.clear();
+        } catch (e) {
+          console.error(e);
+        }
+      }
+
+      return webRProxyHandle;
     })();
   }
   return webRProxyHandlePromise as Promise<WebRProxyHandle>;

--- a/src/Components/LoadingStatus.css
+++ b/src/Components/LoadingStatus.css
@@ -1,0 +1,54 @@
+.loading-status {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  overflow: auto;
+  background-color: inherit;
+  /* Not var(--font-face): that webfont can land after this text paints, making
+     it reflow. */
+  font-family:
+    system-ui,
+    -apple-system,
+    "Segoe UI",
+    Roboto,
+    Helvetica,
+    Arial,
+    sans-serif;
+}
+
+.loading-status .loading-content {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  /* Full width so the stage text's max-width resolves against the viewer rather
+     than against the much narrower animation. */
+  width: 100%;
+  box-sizing: border-box;
+  padding: 1rem;
+  /* Centres vertically while keeping overflow scrollable in a short container.
+     All four margins must stay `auto`: overriding one anchors the content to
+     that edge instead of centring it. */
+  margin: auto;
+}
+
+/* Out of flow, so appearing cannot grow the centred column and shift the
+   animation upwards. */
+.loading-status .loading-stage {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: max-content;
+  max-width: 90%;
+  margin: 0;
+  text-align: center;
+  font-size: 0.7rem;
+  font-style: italic;
+  font-weight: 400;
+  line-height: 1.4;
+  color: #9a9a9a;
+  animation: loading-animation-fade-in 0.5s;
+}

--- a/src/Components/LoadingStatus.tsx
+++ b/src/Components/LoadingStatus.tsx
@@ -1,0 +1,51 @@
+import * as React from "react";
+import { useLoadStatus } from "../hooks/useLoadStatus";
+import type { EngineName } from "../load-status";
+import { ENGINE_LABEL } from "../load-status";
+import { LoadingAnimation } from "./LoadingAnimation";
+import "./LoadingStatus.css";
+
+// A warm load still takes a couple of seconds, because the cache saves the
+// download but not the wasm compile and interpreter boot. This threshold sits
+// above that and well below a cold load, so only slow loads show any text.
+const STATUS_DELAY_MS = 3000;
+
+export function LoadingStatus({ engine }: { engine: EngineName }) {
+  const { stage } = useLoadStatus(engine);
+  const [showStatus, setShowStatus] = React.useState(false);
+
+  React.useEffect(() => {
+    const timer = window.setTimeout(() => setShowStatus(true), STATUS_DELAY_MS);
+    return () => window.clearTimeout(timer);
+  }, []);
+
+  const language = ENGINE_LABEL[engine];
+
+  // Once the engine is ready, the remaining wait belongs to the app: packages
+  // pulled in by its imports, then startup.
+  let stageText: string;
+  if (stage === "idle" || stage === "engine-download") {
+    stageText = `Downloading ${language}…`;
+  } else if (stage === "engine-start") {
+    stageText = `Starting ${language}…`;
+  } else if (stage === "ready") {
+    stageText = "Loading packages and starting app…";
+  } else {
+    // "failed": Viewer shows an error instead of this component, so this is
+    // only a fallback.
+    stageText = "Loading…";
+  }
+
+  return (
+    <div className="loading-status">
+      <div className="loading-content">
+        <LoadingAnimation />
+        {showStatus ? (
+          <p className="loading-stage" role="status" aria-live="polite">
+            {stageText}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/Components/Viewer.css
+++ b/src/Components/Viewer.css
@@ -29,10 +29,8 @@
   align-items: center;
 }
 
-/* The alert's auto margins do the centring; these two are defensive. When the
-   alert is bigger than the viewer the auto margins collapse to zero, and these
-   then decide which edge stays visible. Chromium keeps the top-left reachable
-   either way, but not every engine has always done so. */
+/* Defensive: when the alert outgrows the viewer the auto margins collapse to
+   zero, and these keep the top-left corner reachable rather than clipped. */
 .shinylive-viewer .loading-wrapper.loading-wrapper-error {
   justify-content: flex-start;
   align-items: flex-start;
@@ -40,15 +38,12 @@
 
 .shinylive-viewer .loading-wrapper .error-alert {
   text-align: center;
-  /* One fixed column shared by the hint and the log below. Without it the alert
-     is as wide as its widest child, so a long traceback line would stretch it
-     past the viewer, collapse the auto margins, and leave the hint centred above
-     a flush-left log. Shrinks on a narrow viewer, and never overflows it. */
+  /* One fixed column, shared with the log below. Without it the alert is as wide
+     as its widest child, so a long traceback line stretches it past the viewer. */
   --error-column: 34rem;
   width: var(--error-column);
   max-width: 100%;
-  /* Centres in both axes. All four must stay `auto`: overriding one anchors the
-     alert to that edge instead of centring it. */
+  /* All four sides must stay `auto`; overriding one anchors the alert there. */
   margin: auto;
   font-size: 1.4rem;
   font-family: var(--font-face);
@@ -63,15 +58,11 @@
   margin-bottom: 0.5rem;
 }
 
-/* Sits between the headline and the log, so the fix the user can act on comes
-   before the traceback they probably can't.
-   Shaped by fill alone with no outline, which is how every other surface here is
-   set apart (a grey container holding white panels; the one border in App.css is
-   commented out). The fill is a tint of the app's red, --colors-red / #c10000,
-   so it reads as part of the error. */
+/* Between the headline and the log, so the fix the user can act on comes before
+   the traceback they probably can't. Fill rather than outline, like every other
+   surface here, tinted from the app's red so it reads as part of the error. */
 .shinylive-viewer .loading-wrapper .error-alert .error-recovery {
-  /* Fills the alert's column rather than setting its own width, so it lines up
-     with the log below, which is inset only by its own small padding. */
+  /* No width of its own, so it lines up with the log below. */
   margin: 0.9rem 0;
   padding: 0.75rem 0.9rem;
   border-radius: var(--panel-roundness, 5px);
@@ -95,9 +86,8 @@
   font-weight: 600;
 }
 
-/* The shortcut set apart from the prose so it is scannable without reading the
-   sentence. Same fill-not-outline treatment, one level lighter than the panel,
-   mirroring how a white panel sits on the grey container. */
+/* Set apart so the shortcut is scannable without reading the sentence, one level
+   lighter than the panel it sits on. */
 .shinylive-viewer .loading-wrapper .error-alert .error-recovery kbd {
   display: inline-block;
   padding: 0.05rem 0.4rem;
@@ -115,9 +105,8 @@
   padding: 0.3rem;
 }
 
-/* Keep the traceback's own line breaks, but wrap long lines. Without this the
-   wrapper scrolls sideways instead, so reading the error means dragging through
-   it horizontally. */
+/* Keep the traceback's own line breaks but wrap long ones; otherwise reading the
+   error means dragging sideways. */
 .shinylive-viewer .loading-wrapper .error-alert .error-log pre {
   white-space: pre-wrap;
   overflow-wrap: break-word;

--- a/src/Components/Viewer.css
+++ b/src/Components/Viewer.css
@@ -29,12 +29,27 @@
   align-items: center;
 }
 
+/* The alert's auto margins do the centring; these two are defensive. When the
+   alert is bigger than the viewer the auto margins collapse to zero, and these
+   then decide which edge stays visible. Chromium keeps the top-left reachable
+   either way, but not every engine has always done so. */
 .shinylive-viewer .loading-wrapper.loading-wrapper-error {
-  justify-content: left;
+  justify-content: flex-start;
+  align-items: flex-start;
 }
 
 .shinylive-viewer .loading-wrapper .error-alert {
   text-align: center;
+  /* One fixed column shared by the hint and the log below. Without it the alert
+     is as wide as its widest child, so a long traceback line would stretch it
+     past the viewer, collapse the auto margins, and leave the hint centred above
+     a flush-left log. Shrinks on a narrow viewer, and never overflows it. */
+  --error-column: 34rem;
+  width: var(--error-column);
+  max-width: 100%;
+  /* Centres in both axes. All four must stay `auto`: overriding one anchors the
+     alert to that edge instead of centring it. */
+  margin: auto;
   font-size: 1.4rem;
   font-family: var(--font-face);
   -webkit-animation: loading-animation-fade-in 0.5s;
@@ -48,10 +63,64 @@
   margin-bottom: 0.5rem;
 }
 
+/* Sits between the headline and the log, so the fix the user can act on comes
+   before the traceback they probably can't.
+   Shaped by fill alone with no outline, which is how every other surface here is
+   set apart (a grey container holding white panels; the one border in App.css is
+   commented out). The fill is a tint of the app's red, --colors-red / #c10000,
+   so it reads as part of the error. */
+.shinylive-viewer .loading-wrapper .error-alert .error-recovery {
+  /* Fills the alert's column rather than setting its own width, so it lines up
+     with the log below, which is inset only by its own small padding. */
+  margin: 0.9rem 0;
+  padding: 0.75rem 0.9rem;
+  border-radius: var(--panel-roundness, 5px);
+  background-color: #fadfdf;
+  color: #5e3737;
+  font-size: 0.85rem;
+  line-height: 1.55;
+  text-align: left;
+}
+
+.shinylive-viewer .loading-wrapper .error-alert .error-recovery p {
+  margin: 0;
+}
+
+.shinylive-viewer .loading-wrapper .error-alert .error-recovery p + p {
+  margin-top: 0.45rem;
+}
+
+.shinylive-viewer .loading-wrapper .error-alert .error-recovery-lead {
+  color: #912828;
+  font-weight: 600;
+}
+
+/* The shortcut set apart from the prose so it is scannable without reading the
+   sentence. Same fill-not-outline treatment, one level lighter than the panel,
+   mirroring how a white panel sits on the grey container. */
+.shinylive-viewer .loading-wrapper .error-alert .error-recovery kbd {
+  display: inline-block;
+  padding: 0.05rem 0.4rem;
+  border-radius: var(--button-roundness, 5px);
+  background-color: var(--colors-white, white);
+  color: #912828;
+  font-family: var(--font-mono-face, monospace);
+  font-size: 0.9em;
+  white-space: nowrap;
+}
+
 .shinylive-viewer .loading-wrapper .error-alert .error-log {
   font-size: 0.7rem;
   text-align: left;
   padding: 0.3rem;
+}
+
+/* Keep the traceback's own line breaks, but wrap long lines. Without this the
+   wrapper scrolls sideways instead, so reading the error means dragging through
+   it horizontally. */
+.shinylive-viewer .loading-wrapper .error-alert .error-log pre {
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
 }
 
 @keyframes loading-animation-fade-in {

--- a/src/Components/Viewer.tsx
+++ b/src/Components/Viewer.tsx
@@ -88,11 +88,8 @@ function createHttpRequestChannel(
   return httpRequestChannel;
 }
 
-// Shown above the error log for every failure, engine or app. A stale cache is
-// the most common cause we can actually tell the user how to fix, and a normal
-// reload does not clear it. There is deliberately no reload button: JS cannot
-// force a cache-bypassing reload, so a button would do the one thing that has
-// already failed.
+// Recovery hint shown above the error log when the engine itself fails to load.
+// A stale cache is a common cause, so suggest the user to try a hard refresh
 function RecoveryHint() {
   return (
     <div className="error-recovery">
@@ -104,6 +101,38 @@ function RecoveryHint() {
         If that doesn’t help, clear this site’s cookies and cached data, then
         reload. Stale cached files are a common cause of loading failures.
       </p>
+    </div>
+  );
+}
+
+// The failure screen for both engine and app syntax failures. `kind` dictates
+// if the recovery hint is shown in the engine-failure case, which isn't needed
+// relevant for an application syntax error (it just shows the traceback instead)
+export function ViewerError({
+  kind,
+  engine,
+  message,
+}: {
+  kind: "engine" | "app";
+  engine: EngineName;
+  message: string | null;
+}) {
+  return (
+    <div className="loading-wrapper loading-wrapper-error">
+      <div className="error-alert">
+        <div className="error-icon">
+          <img src={skull} alt="skull" />
+        </div>
+        <div className="error-message">
+          {kind === "engine"
+            ? `Error loading ${ENGINE_LABEL[engine]}!`
+            : "Error starting app!"}
+        </div>
+        {kind === "engine" ? <RecoveryHint /> : null}
+        <div className="error-log">
+          <pre>{message}</pre>
+        </div>
+      </div>
     </div>
   );
 }
@@ -383,22 +412,11 @@ export function Viewer({
     <div className="shinylive-viewer">
       <iframe ref={viewerFrameRef} className="app-frame" />
       {engineFailed || appRunningState === "errored" ? (
-        <div className="loading-wrapper loading-wrapper-error">
-          <div className="error-alert">
-            <div className="error-icon">
-              <img src={skull} alt="skull" />
-            </div>
-            <div className="error-message">
-              {engineFailed
-                ? `Error loading ${ENGINE_LABEL[engine]}!`
-                : "Error starting app!"}
-            </div>
-            <RecoveryHint />
-            <div className="error-log">
-              <pre>{engineFailed ? engineStatus.error : lastErrorMessage}</pre>
-            </div>
-          </div>
-        </div>
+        <ViewerError
+          kind={engineFailed ? "engine" : "app"}
+          engine={engine}
+          message={engineFailed ? engineStatus.error : lastErrorMessage}
+        />
       ) : appRunningState === "loading" ? (
         <div className="loading-wrapper">
           <LoadingStatus engine={engine} />

--- a/src/Components/Viewer.tsx
+++ b/src/Components/Viewer.tsx
@@ -1,9 +1,12 @@
 import * as React from "react";
+import { useLoadStatus } from "../hooks/useLoadStatus";
+import type { EngineName } from "../load-status";
+import { ENGINE_LABEL } from "../load-status";
 import type { PyodideProxy } from "../pyodide-proxy";
 import * as utils from "../utils";
 import type { WebRProxy } from "../webr-proxy";
 import type { ProxyHandle } from "./App";
-import { LoadingAnimation } from "./LoadingAnimation";
+import { LoadingStatus } from "./LoadingStatus";
 import "./Viewer.css";
 import type { FileContent } from "./filecontent";
 import skull from "./skull.svg";
@@ -128,6 +131,7 @@ export function Viewer({
   setViewerMethods,
   devMode = false,
   setWindowTitle = false,
+  engine,
 }: {
   proxyHandle: ProxyHandle;
   setViewerMethods: React.Dispatch<React.SetStateAction<ViewerMethods>>;
@@ -138,6 +142,7 @@ export function Viewer({
         defaultTitle: string;
       }
     | false;
+  engine: EngineName;
 }) {
   const viewerFrameRef = React.useRef<HTMLIFrameElement>(null);
   const [appRunningState, setAppRunningState] = React.useState<
@@ -147,6 +152,7 @@ export function Viewer({
   const [lastErrorMessage, setLastErrorMessage] = React.useState<string | null>(
     null,
   );
+  const engineStatus = useLoadStatus(engine);
 
   // Add effect to monitor iframe title changes
   React.useEffect(() => {
@@ -343,24 +349,30 @@ export function Viewer({
     });
   }, [proxyHandle.shinyReady]);
 
+  const engineFailed = engineStatus.stage === "failed";
+
   return (
     <div className="shinylive-viewer">
       <iframe ref={viewerFrameRef} className="app-frame" />
-      {appRunningState === "loading" ? (
-        <div className="loading-wrapper">
-          <LoadingAnimation />
-        </div>
-      ) : appRunningState === "errored" ? (
+      {engineFailed || appRunningState === "errored" ? (
         <div className="loading-wrapper loading-wrapper-error">
           <div className="error-alert">
             <div className="error-icon">
               <img src={skull} alt="skull" />
             </div>
-            <div className="error-message">Error starting app!</div>
+            <div className="error-message">
+              {engineFailed
+                ? `Error loading ${ENGINE_LABEL[engine]}!`
+                : "Error starting app!"}
+            </div>
             <div className="error-log">
-              <pre>{lastErrorMessage}</pre>
+              <pre>{engineFailed ? engineStatus.error : lastErrorMessage}</pre>
             </div>
           </div>
+        </div>
+      ) : appRunningState === "loading" ? (
+        <div className="loading-wrapper">
+          <LoadingStatus engine={engine} />
         </div>
       ) : null}
     </div>

--- a/src/Components/Viewer.tsx
+++ b/src/Components/Viewer.tsx
@@ -107,8 +107,8 @@ function RecoveryHint() {
 }
 
 // The failure screen for both engine and app syntax failures. `kind` dictates
-// if the recovery hint is shown in the engine-failure case, which isn't needed
-// relevant for an application syntax error (it just shows the traceback instead)
+// if the recovery hint is shown in the engine-failure case, which isn't
+// relevant for an application-level error (it shows the traceback/error instead)
 export function ViewerError({
   kind,
   engine,
@@ -284,11 +284,12 @@ export function Viewer({
             captureStreams: false,
           });
           // .start_app reports failure by returning a status list rather than
-          // raising, because captureConditions is off here: a raised error would
+          // raising, because captureConditions is false here: a raised error would
           // go to the terminal and never reach this catch, and the viewer would
-          // show an app that never started. Evaluated on this shelter, rather
-          // than through runRAsync, because runRAsync purges its own shelter
-          // before returning -- the list has to outlive the call.
+          // show an app that never started. We evaluate on the shelter rather
+          // than through runRAsync because runRAsync purges its own shelter
+          // before returning, and we need the list to outlive the call to show
+          // information about the error to the user.
           const startResult = await shelter.evalR(
             ".start_app(appName, appDir, devMode)",
             {
@@ -299,22 +300,18 @@ export function Viewer({
           );
           const start = await startResult.toJs();
           // Anything other than an explicit "ok" is a failure, including a reply
-          // that did not survive the conversion above: a startup whose outcome
-          // cannot be read is not one to go on and display an app for.
+          // that did not survive the conversion above.
           if (rCharacterField(start, "status")[0] !== "ok") {
             const message =
               rCharacterField(start, "message")[0] ||
-              // Distinct from .start_app's own no-message fallback, so the two
-              // are told apart: that one means R raised an empty condition,
-              // this one means no readable status came back at all.
+              // Distinct from .start_app's own no-message fallback to distinguish
+              // between R raising an empty condition and no readable status coming
+              // back at all.
               "The app failed to start, and R reported no status.";
             const call = rCharacterField(start, "call")[0];
             const error = new Error(
               call ? `Error in ${call}: ${message}` : message,
             );
-            // Not branched on: a third category on the error screen would be a
-            // UX change. Carried so the console says what kind of failure it
-            // was.
             console.error("R startup failure", rCharacterField(start, "class"));
             throw error;
           }

--- a/src/Components/Viewer.tsx
+++ b/src/Components/Viewer.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import type { RObject } from "webr";
+import { rCharacterField } from "../r-status";
 import { useLoadStatus } from "../hooks/useLoadStatus";
 import type { EngineName } from "../load-status";
 import { ENGINE_LABEL } from "../load-status";
@@ -173,33 +173,6 @@ async function resetRAppFrame(
   await utils.sleep(200);
 }
 
-/** One named character element of webR's serialisation of an R list.
- *
- * `RObject.toJs()` returns a tagged tree, not a plain object: an R list arrives
- * as `{ type, names, values }`, and each element is itself either a
- * `{ type, names, values }` node or an already-unwrapped scalar -- webr's
- * `WebRDataJsNode.values` is typed as holding either. So both levels are
- * handled here, and the result is a `string[]` because every R character vector
- * has a length.
- *
- * An absent or unreadable field gives `[]` rather than a guess, so a reply that
- * does not match this shape fails loudly at the caller instead of reading as
- * success.
- */
-function rCharacterField(
-  js: Awaited<ReturnType<RObject["toJs"]>>,
-  name: string,
-): string[] {
-  if (!("names" in js) || js.names === null || !("values" in js)) return [];
-  const index = js.names.indexOf(name);
-  if (index === -1) return [];
-  const element: unknown = js.values[index];
-  if (typeof element === "string") return [element];
-  if (element === null || typeof element !== "object") return [];
-  const values: unknown = (element as { values?: unknown }).values;
-  if (!Array.isArray(values)) return [];
-  return values.filter((value): value is string => typeof value === "string");
-}
 
 // =============================================================================
 // Viewer component

--- a/src/Components/Viewer.tsx
+++ b/src/Components/Viewer.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import type { RObject } from "webr";
 import { useLoadStatus } from "../hooks/useLoadStatus";
 import type { EngineName } from "../load-status";
 import { ENGINE_LABEL } from "../load-status";
@@ -172,6 +173,34 @@ async function resetRAppFrame(
   await utils.sleep(200);
 }
 
+/** One named character element of webR's serialisation of an R list.
+ *
+ * `RObject.toJs()` returns a tagged tree, not a plain object: an R list arrives
+ * as `{ type, names, values }`, and each element is itself either a
+ * `{ type, names, values }` node or an already-unwrapped scalar -- webr's
+ * `WebRDataJsNode.values` is typed as holding either. So both levels are
+ * handled here, and the result is a `string[]` because every R character vector
+ * has a length.
+ *
+ * An absent or unreadable field gives `[]` rather than a guess, so a reply that
+ * does not match this shape fails loudly at the caller instead of reading as
+ * success.
+ */
+function rCharacterField(
+  js: Awaited<ReturnType<RObject["toJs"]>>,
+  name: string,
+): string[] {
+  if (!("names" in js) || js.names === null || !("values" in js)) return [];
+  const index = js.names.indexOf(name);
+  if (index === -1) return [];
+  const element: unknown = js.values[index];
+  if (typeof element === "string") return [element];
+  if (element === null || typeof element !== "object") return [];
+  const values: unknown = (element as { values?: unknown }).values;
+  if (!Array.isArray(values)) return [];
+  return values.filter((value): value is string => typeof value === "string");
+}
+
 // =============================================================================
 // Viewer component
 // =============================================================================
@@ -281,11 +310,13 @@ export function Viewer({
             env: { files, appDir },
             captureStreams: false,
           });
-          // .start_app reports failure by returning the message rather than
-          // raising, because captureConditions is off here. evalRString is used
-          // instead of runRAsync so webR marshals the string before releasing
-          // the R object.
-          const startError = await webRProxy.webR.evalRString(
+          // .start_app reports failure by returning a status list rather than
+          // raising, because captureConditions is off here: a raised error would
+          // go to the terminal and never reach this catch, and the viewer would
+          // show an app that never started. Evaluated on this shelter, rather
+          // than through runRAsync, because runRAsync purges its own shelter
+          // before returning -- the list has to outlive the call.
+          const startResult = await shelter.evalR(
             ".start_app(appName, appDir, devMode)",
             {
               env: { appName, appDir, devMode },
@@ -293,7 +324,27 @@ export function Viewer({
               captureStreams: false,
             },
           );
-          if (startError) throw new Error(startError);
+          const start = await startResult.toJs();
+          // Anything other than an explicit "ok" is a failure, including a reply
+          // that did not survive the conversion above: a startup whose outcome
+          // cannot be read is not one to go on and display an app for.
+          if (rCharacterField(start, "status")[0] !== "ok") {
+            const message =
+              rCharacterField(start, "message")[0] ??
+              // Distinct from .start_app's own no-message fallback, so the two
+              // are told apart: that one means R raised an empty condition,
+              // this one means no readable status came back at all.
+              "The app failed to start, and R reported no status.";
+            const call = rCharacterField(start, "call")[0];
+            const error = new Error(
+              call ? `Error in ${call}: ${message}` : message,
+            );
+            // Not branched on: a third category on the error screen would be a
+            // UX change. Carried so the console says what kind of failure it
+            // was.
+            console.error("R startup failure", rCharacterField(start, "class"));
+            throw error;
+          }
         } finally {
           await shelter.purge();
         }

--- a/src/Components/Viewer.tsx
+++ b/src/Components/Viewer.tsx
@@ -330,7 +330,7 @@ export function Viewer({
           // cannot be read is not one to go on and display an app for.
           if (rCharacterField(start, "status")[0] !== "ok") {
             const message =
-              rCharacterField(start, "message")[0] ??
+              rCharacterField(start, "message")[0] ||
               // Distinct from .start_app's own no-message fallback, so the two
               // are told apart: that one means R raised an empty condition,
               // this one means no readable status came back at all.

--- a/src/Components/Viewer.tsx
+++ b/src/Components/Viewer.tsx
@@ -88,6 +88,26 @@ function createHttpRequestChannel(
   return httpRequestChannel;
 }
 
+// Shown above the error log for every failure, engine or app. A stale cache is
+// the most common cause we can actually tell the user how to fix, and a normal
+// reload does not clear it. There is deliberately no reload button: JS cannot
+// force a cache-bypassing reload, so a button would do the one thing that has
+// already failed.
+function RecoveryHint() {
+  return (
+    <div className="error-recovery">
+      <p className="error-recovery-lead">
+        First, try a hard refresh: <kbd>Cmd+Shift+R</kbd> on macOS, or{" "}
+        <kbd>Ctrl+Shift+R</kbd> on Windows and Linux.
+      </p>
+      <p>
+        If that doesn’t help, clear this site’s cookies and cached data, then
+        reload. Stale cached files are a common cause of loading failures.
+      </p>
+    </div>
+  );
+}
+
 async function resetPyAppFrame(
   pyodide: PyodideProxy,
   appName: string,
@@ -232,11 +252,19 @@ export function Viewer({
             env: { files, appDir },
             captureStreams: false,
           });
-          await webRProxy.runRAsync(".start_app(appName, appDir, devMode)", {
-            env: { appName, appDir, devMode },
-            captureConditions: false,
-            captureStreams: false,
-          });
+          // .start_app reports failure by returning the message rather than
+          // raising, because captureConditions is off here. evalRString is used
+          // instead of runRAsync so webR marshals the string before releasing
+          // the R object.
+          const startError = await webRProxy.webR.evalRString(
+            ".start_app(appName, appDir, devMode)",
+            {
+              env: { appName, appDir, devMode },
+              captureConditions: false,
+              captureStreams: false,
+            },
+          );
+          if (startError) throw new Error(startError);
         } finally {
           await shelter.purge();
         }
@@ -365,6 +393,7 @@ export function Viewer({
                 ? `Error loading ${ENGINE_LABEL[engine]}!`
                 : "Error starting app!"}
             </div>
+            <RecoveryHint />
             <div className="error-log">
               <pre>{engineFailed ? engineStatus.error : lastErrorMessage}</pre>
             </div>

--- a/src/engine-load-guard.test.ts
+++ b/src/engine-load-guard.test.ts
@@ -1,0 +1,250 @@
+import { checkEngineAssetReachable } from "./engine-load-guard";
+
+// The four-byte wasm preamble: \0asm
+const WASM = new Uint8Array([0x00, 0x61, 0x73, 0x6d]);
+
+// jsdom (jest-environment-jsdom) does not implement fetch, so there is no
+// existing property for jest.spyOn() to replace. Give it one; every test below
+// swaps in its own implementation before use.
+if (typeof globalThis.fetch === "undefined") {
+  (globalThis as unknown as { fetch: unknown }).fetch = () => {
+    throw new Error("fetch called without a stub");
+  };
+}
+
+let fetchSpy: jest.SpyInstance;
+
+afterEach(() => {
+  fetchSpy.mockRestore();
+});
+
+function stubFetch(impl: (url: string, init?: RequestInit) => unknown): void {
+  fetchSpy = jest
+    .spyOn(globalThis, "fetch")
+    .mockImplementation(impl as typeof fetch);
+}
+
+// A minimal Response whose body yields `chunks` then closes. Only the fields
+// checkEngineAssetReachable() touches are present: a fake is clearer here than
+// a real Response, whose body cannot be built from parts in jsdom.
+function response(status: number, chunks: Uint8Array[]) {
+  let i = 0;
+  let cancelled = false;
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    body: {
+      getReader: () => ({
+        read: async () =>
+          i < chunks.length
+            ? { done: false, value: chunks[i++] }
+            : { done: true, value: undefined },
+        cancel: async () => {
+          cancelled = true;
+        },
+      }),
+    },
+    // Exposed so the cancel assertion can read it back.
+    get cancelled() {
+      return cancelled;
+    },
+  };
+}
+
+function toBytes(body: string | number[]): Uint8Array {
+  return typeof body === "string"
+    ? new TextEncoder().encode(body)
+    : new Uint8Array(body);
+}
+
+test("reachable asset returns null", async () => {
+  stubFetch(() => response(200, [WASM]));
+  await expect(
+    checkEngineAssetReachable("python", "/shinylive/pyodide/"),
+  ).resolves.toBeNull();
+});
+
+test("checks the engine's core wasm at the given base URL", async () => {
+  stubFetch(() => response(200, [WASM]));
+  await checkEngineAssetReachable("python", "/shinylive/pyodide/");
+  await checkEngineAssetReachable("r", "/shinylive/webr/");
+  expect(fetchSpy.mock.calls.map((c) => c[0])).toEqual([
+    "/shinylive/pyodide/pyodide.asm.wasm",
+    "/shinylive/webr/R.wasm",
+  ]);
+});
+
+test("uses a plain GET, never HEAD", async () => {
+  // A HEAD would silently break offline-but-cached loads.
+  stubFetch(() => response(200, [WASM]));
+  await checkEngineAssetReachable("python", "/shinylive/pyodide/");
+  const [url, init] = fetchSpy.mock.calls[0];
+  expect(url).toContain("/shinylive/pyodide/pyodide.asm.wasm");
+  expect((init as RequestInit | undefined)?.method?.toUpperCase()).not.toBe(
+    "HEAD",
+  );
+});
+
+test("a 404 is reported with the URL and the status", async () => {
+  stubFetch(() => response(404, []));
+  const msg = await checkEngineAssetReachable("python", "/shinylive/pyodide/");
+  expect(msg).toMatch(/Python engine could not be downloaded/);
+  expect(msg).toMatch(/pyodide\.asm\.wasm/);
+  expect(msg).toMatch(/HTTP 404/);
+});
+
+test("a 5xx is treated as a failure too", async () => {
+  // No body at all here (unlike the 404 case above), so both shapes of a
+  // failed response's body are exercised.
+  stubFetch(() => ({ ok: false, status: 503, body: null }));
+  const msg = await checkEngineAssetReachable("r", "/shinylive/webr/");
+  expect(msg).toMatch(/R engine could not be downloaded/);
+  expect(msg).toMatch(/HTTP 503/);
+});
+
+test("a network error is reported without a status", async () => {
+  stubFetch(() => Promise.reject(new Error("Failed to fetch")));
+  const msg = await checkEngineAssetReachable("r", "/shinylive/webr/");
+  expect(msg).toMatch(/unreachable/);
+  expect(msg).toMatch(/Failed to fetch/);
+  expect(msg).not.toMatch(/HTTP/);
+
+  // fetch() can also reject with something that isn't an Error (a string
+  // thrown by an odd polyfill, say); the message must still surface.
+  fetchSpy.mockRestore();
+  stubFetch(() => Promise.reject("offline"));
+  const msg2 = await checkEngineAssetReachable("r", "/shinylive/webr/");
+  expect(msg2).toMatch(/offline/);
+});
+
+test("the body is cancelled rather than downloaded", async () => {
+  // The core wasm is ~10-18 MB. Only the first few bytes are wanted, so the
+  // transfer must be stopped rather than run to completion.
+  const res = response(200, [WASM]);
+  stubFetch(() => res);
+  await checkEngineAssetReachable("python", "/shinylive/pyodide/");
+  expect(res.cancelled).toBe(true);
+});
+
+test("only the leading bytes are read, not the whole body", async () => {
+  // One chunk carries the magic number; the reader must not ask for the rest.
+  let reads = 0;
+  stubFetch(() => ({
+    ok: true,
+    status: 200,
+    body: {
+      getReader: () => ({
+        read: async () => {
+          reads++;
+          return { done: false, value: WASM };
+        },
+        cancel: async () => undefined,
+      }),
+    },
+  }));
+  await expect(
+    checkEngineAssetReachable("python", "/shinylive/pyodide/"),
+  ).resolves.toBeNull();
+  expect(reads).toBe(1);
+});
+
+// A captive portal or an SPA index.html fallback answers with 200. Handing
+// either to the engine hangs it, so the check has to look past the status.
+describe.each([
+  ["an HTML page", "<!doctype html>\n<html><body>Sign in</body></html>"],
+  ["other non-wasm bytes", [0xde, 0xad, 0xbe, 0xef]],
+  ["an empty body", []],
+  ["a body truncated inside the magic number", [0x00, 0x61]],
+])("a 200 carrying %s is rejected", (_name, body) => {
+  test("reports corruption", async () => {
+    stubFetch(() => response(200, [toBytes(body)]));
+    await expect(
+      checkEngineAssetReachable("python", "/shinylive/pyodide/"),
+    ).resolves.toMatch(/appears to be corrupted/);
+  });
+});
+
+test("the magic number may arrive split across chunks", async () => {
+  // A stream is free to deliver one byte at a time; that is not a failure.
+  // An empty read (no value) can also happen mid-stream and must be skipped
+  // rather than counted as bytes.
+  let i = 0;
+  const chunks: (Uint8Array | undefined)[] = [
+    toBytes([0x00]),
+    undefined,
+    toBytes([0x61, 0x73]),
+    toBytes([0x6d, 0x01]),
+  ];
+  stubFetch(() => ({
+    ok: true,
+    status: 200,
+    body: {
+      getReader: () => ({
+        read: async () =>
+          i < chunks.length
+            ? { done: false, value: chunks[i++] }
+            : { done: true, value: undefined },
+        cancel: async () => undefined,
+      }),
+    },
+  }));
+  await expect(
+    checkEngineAssetReachable("python", "/shinylive/pyodide/"),
+  ).resolves.toBeNull();
+});
+
+test("a body that cannot be cancelled does not fail the check", async () => {
+  stubFetch(() => ({
+    ok: true,
+    status: 200,
+    body: {
+      getReader: () => ({
+        read: async () => ({ done: false, value: WASM }),
+        cancel: async () => {
+          throw new Error("locked");
+        },
+      }),
+    },
+  }));
+  await expect(
+    checkEngineAssetReachable("python", "/shinylive/pyodide/"),
+  ).resolves.toBeNull();
+});
+
+test("a bodyless response does not fail the check", async () => {
+  stubFetch(() => ({ ok: true, status: 200, body: null }));
+  await expect(
+    checkEngineAssetReachable("python", "/shinylive/pyodide/"),
+  ).resolves.toBeNull();
+});
+
+test("a body with no getReader does not fail the check", async () => {
+  // Guards against an environment where body is present but not a stream: the
+  // check must decline to judge rather than throw and break the load.
+  stubFetch(() => ({
+    ok: true,
+    status: 200,
+    body: { cancel: async () => undefined },
+  }));
+  await expect(
+    checkEngineAssetReachable("python", "/shinylive/pyodide/"),
+  ).resolves.toBeNull();
+});
+
+test("a body that throws mid-read does not fail the check", async () => {
+  stubFetch(() => ({
+    ok: true,
+    status: 200,
+    body: {
+      getReader: () => ({
+        read: async () => {
+          throw new Error("network reset");
+        },
+        cancel: async () => undefined,
+      }),
+    },
+  }));
+  await expect(
+    checkEngineAssetReachable("python", "/shinylive/pyodide/"),
+  ).resolves.toBeNull();
+});

--- a/src/engine-load-guard.test.ts
+++ b/src/engine-load-guard.test.ts
@@ -27,21 +27,28 @@ function stubFetch(impl: (url: string, init?: RequestInit) => unknown): void {
 // A minimal Response whose body yields `chunks` then closes. Only the fields
 // checkEngineAssetReachable() touches are present: a fake is clearer here than
 // a real Response, whose body cannot be built from parts in jsdom.
+//
+// A real ReadableStream exposes `cancel()` both on the stream itself and on
+// its reader; the source calls the former on the failure path (a non-ok
+// response) and the latter on the success path (inside readHead). Both are
+// wired to the same flag so either path's release can be observed.
 function response(status: number, chunks: Uint8Array[]) {
   let i = 0;
   let cancelled = false;
+  const cancel = async () => {
+    cancelled = true;
+  };
   return {
     ok: status >= 200 && status < 300,
     status,
     body: {
+      cancel,
       getReader: () => ({
         read: async () =>
           i < chunks.length
             ? { done: false, value: chunks[i++] }
             : { done: true, value: undefined },
-        cancel: async () => {
-          cancelled = true;
-        },
+        cancel,
       }),
     },
     // Exposed so the cancel assertion can read it back.
@@ -80,17 +87,20 @@ test("uses a plain GET, never HEAD", async () => {
   await checkEngineAssetReachable("python", "/shinylive/pyodide/");
   const [url, init] = fetchSpy.mock.calls[0];
   expect(url).toContain("/shinylive/pyodide/pyodide.asm.wasm");
-  expect((init as RequestInit | undefined)?.method?.toUpperCase()).not.toBe(
-    "HEAD",
-  );
+  const method = (init as RequestInit | undefined)?.method;
+  expect(method === undefined || method.toUpperCase() === "GET").toBe(true);
 });
 
 test("a 404 is reported with the URL and the status", async () => {
-  stubFetch(() => response(404, []));
+  // Only the status is needed for a failed response, so the body is released
+  // rather than read; capture the fixture to observe that release happens.
+  const res = response(404, []);
+  stubFetch(() => res);
   const msg = await checkEngineAssetReachable("python", "/shinylive/pyodide/");
   expect(msg).toMatch(/Python engine could not be downloaded/);
   expect(msg).toMatch(/pyodide\.asm\.wasm/);
   expect(msg).toMatch(/HTTP 404/);
+  expect(res.cancelled).toBe(true);
 });
 
 test("a 5xx is treated as a failure too", async () => {
@@ -100,6 +110,21 @@ test("a 5xx is treated as a failure too", async () => {
   const msg = await checkEngineAssetReachable("r", "/shinylive/webr/");
   expect(msg).toMatch(/R engine could not be downloaded/);
   expect(msg).toMatch(/HTTP 503/);
+
+  // Releasing the body is best-effort: a body that cannot be cancelled must
+  // not stop the failure from being reported.
+  fetchSpy.mockRestore();
+  stubFetch(() => ({
+    ok: false,
+    status: 503,
+    body: {
+      cancel: async () => {
+        throw new Error("already released");
+      },
+    },
+  }));
+  const msg2 = await checkEngineAssetReachable("r", "/shinylive/webr/");
+  expect(msg2).toMatch(/HTTP 503/);
 });
 
 test("a network error is reported without a status", async () => {
@@ -148,21 +173,54 @@ test("only the leading bytes are read, not the whole body", async () => {
   expect(reads).toBe(1);
 });
 
+type CorruptionCase = [
+  name: string,
+  engine: "python" | "r",
+  baseUrl: string,
+  body: string | number[],
+  // Not every row asserts the engine label; the originals for "an empty
+  // body" and "a body truncated inside the magic number" checked only the
+  // generic corruption message.
+  label?: RegExp,
+];
+
+const CORRUPTION_CASES: CorruptionCase[] = [
+  [
+    "an HTML page",
+    "python",
+    "/shinylive/pyodide/",
+    "<!doctype html>\n<html><body>Sign in</body></html>",
+    /Python engine could not be downloaded/,
+  ],
+  [
+    "other non-wasm bytes",
+    "r",
+    "/shinylive/webr/",
+    [0xde, 0xad, 0xbe, 0xef],
+    /R engine could not be downloaded/,
+  ],
+  ["an empty body", "python", "/shinylive/pyodide/", []],
+  [
+    "a body truncated inside the magic number",
+    "python",
+    "/shinylive/pyodide/",
+    [0x00, 0x61],
+  ],
+];
+
 // A captive portal or an SPA index.html fallback answers with 200. Handing
 // either to the engine hangs it, so the check has to look past the status.
-describe.each([
-  ["an HTML page", "<!doctype html>\n<html><body>Sign in</body></html>"],
-  ["other non-wasm bytes", [0xde, 0xad, 0xbe, 0xef]],
-  ["an empty body", []],
-  ["a body truncated inside the magic number", [0x00, 0x61]],
-])("a 200 carrying %s is rejected", (_name, body) => {
-  test("reports corruption", async () => {
-    stubFetch(() => response(200, [toBytes(body)]));
-    await expect(
-      checkEngineAssetReachable("python", "/shinylive/pyodide/"),
-    ).resolves.toMatch(/appears to be corrupted/);
-  });
-});
+describe.each(CORRUPTION_CASES)(
+  "a 200 carrying %s is rejected",
+  (_name, engine, baseUrl, body, label) => {
+    test("reports corruption", async () => {
+      stubFetch(() => response(200, [toBytes(body)]));
+      const msg = await checkEngineAssetReachable(engine, baseUrl);
+      expect(msg).toMatch(/appears to be corrupted/);
+      if (label) expect(msg).toMatch(label);
+    });
+  },
+);
 
 test("the magic number may arrive split across chunks", async () => {
   // A stream is free to deliver one byte at a time; that is not a failure.

--- a/src/engine-load-guard.ts
+++ b/src/engine-load-guard.ts
@@ -1,11 +1,12 @@
 // Reports an engine asset that cannot be downloaded, so the loader can show an
-// error instead of spinning.
+// error instead of spinning endlessly.
 //
 // Neither Pyodide's loadPyodide() nor webR's init() settles when the engine's
-// wasm cannot be instantiated — not resolved, not rejected — and neither leaves
-// an error the page can catch. Checking the asset ourselves covers the common
-// cause, which is that it isn't there. A file that downloads but is unusable
-// still spins forever; that gap is left open on purpose.
+// wasm cannot be instantiated and neither leaves an error the page can catch.
+// Checking the asset ourselves covers the cases where the file is corrupt, missing,
+// or otherwise does not appear to be valid wasm. A response that is a
+// genuine wasm module but the wrong one (e.g. a stale cached build) still
+// spins forever; closing that would need a timeout, which this does not attempt.
 
 import type { EngineName } from "./load-status";
 import { ENGINE_LABEL } from "./load-status";
@@ -16,40 +17,91 @@ const CORE_WASM: Record<EngineName, string> = {
   r: "R.wasm",
 };
 
+// Every WebAssembly module begins with these four magic bytes ("\0asm").
+const WASM_MAGIC = [0x00, 0x61, 0x73, 0x6d];
+
 /**
- * An error message if the engine's core wasm cannot be fetched, else null.
+ * The first `n` bytes of a response body, or null if it cannot be read.
  *
- * A GET, not a HEAD, so this makes the same request the engine will: the service
- * worker returns early for non-GET, and hosts need not answer HEAD alike.
- * fetch() resolves on headers, so reading only the status costs ~50ms even for an
- * 18 MB file, and the body is dropped rather than read.
+ * Reads whole chunks until it has enough and then cancels, so the transfer stops
+ * early instead of running to completion. Returns fewer than `n` bytes if the
+ * body ends first, which is itself a failure worth reporting.
+ */
+async function readHead(
+  response: Response,
+  n: number,
+): Promise<Uint8Array | null> {
+  // Nothing here may throw: this runs to decide whether loading can proceed, so
+  // a body that cannot be read has to mean "no opinion", not a failed load.
+  const body = response.body;
+  if (!body || typeof body.getReader !== "function") return null;
+  const reader = body.getReader();
+
+  const head = new Uint8Array(n);
+  let filled = 0;
+  try {
+    while (filled < n) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      const take = Math.min(value.length, n - filled);
+      head.set(value.subarray(0, take), filled);
+      filled += take;
+    }
+  } catch {
+    // A body that fails mid-read tells us nothing the caller can act on.
+    return null;
+  } finally {
+    // Stop the transfer; the rest of the file is the engine's to download.
+    await reader.cancel().catch(() => undefined);
+  }
+  return head.subarray(0, filled);
+}
+
+/**
+ * Raise an error if the engine's core wasm cannot be fetched, else null.
+ *
+ * fetch() resolves on headers and the body is cancelled as soon as the first few
+ * bytes are in hand, so does not trigger the whole download (just checks it's available).
  */
 export async function checkEngineAssetReachable(
   engine: EngineName,
   baseUrl: string,
 ): Promise<string | null> {
   const url = baseUrl + CORE_WASM[engine];
+  const prefix = `The ${ENGINE_LABEL[engine]} engine could not be downloaded.`;
+
   let response: Response;
   try {
     response = await fetch(url);
   } catch (e) {
     // Offline or DNS failure: no status to report.
-    return `The ${
-      ENGINE_LABEL[engine]
-    } engine could not be downloaded. ${url} is unreachable (${
+    return `${prefix} ${url} is unreachable (${
       e instanceof Error ? e.message : String(e)
     }).`;
   }
 
-  // Only the status was needed; releasing the body is best-effort.
-  try {
-    await response.body?.cancel();
-  } catch {
-    /* already released */
+  if (!response.ok) {
+    // Only the status was needed; releasing the body is best-effort.
+    try {
+      await response.body?.cancel();
+    } catch {
+      /* already released */
+    }
+    return `${prefix} ${url} returned HTTP ${response.status}.`;
   }
 
-  if (!response.ok) {
-    return `The ${ENGINE_LABEL[engine]} engine could not be downloaded. ${url} returned HTTP ${response.status}.`;
+  // Check the head of the response for wasm magic bytes to potentially
+  // detect a malformed/corrupted download and alert the user.
+  const head = await readHead(response, WASM_MAGIC.length);
+  if (head === null) return null; // Unreadable body; nothing to conclude.
+
+  const isWasm =
+    head.length === WASM_MAGIC.length &&
+    WASM_MAGIC.every((byte, i) => head[i] === byte);
+  if (!isWasm) {
+    return `${prefix} The file at ${url} appears to be corrupted.`;
   }
+
   return null;
 }

--- a/src/engine-load-guard.ts
+++ b/src/engine-load-guard.ts
@@ -1,0 +1,55 @@
+// Reports an engine asset that cannot be downloaded, so the loader can show an
+// error instead of spinning.
+//
+// Neither Pyodide's loadPyodide() nor webR's init() settles when the engine's
+// wasm cannot be instantiated — not resolved, not rejected — and neither leaves
+// an error the page can catch. Checking the asset ourselves covers the common
+// cause, which is that it isn't there. A file that downloads but is unusable
+// still spins forever; that gap is left open on purpose.
+
+import type { EngineName } from "./load-status";
+import { ENGINE_LABEL } from "./load-status";
+
+// wasm engine files to check
+const CORE_WASM: Record<EngineName, string> = {
+  python: "pyodide.asm.wasm",
+  r: "R.wasm",
+};
+
+/**
+ * An error message if the engine's core wasm cannot be fetched, else null.
+ *
+ * A GET, not a HEAD, so this makes the same request the engine will: the service
+ * worker returns early for non-GET, and hosts need not answer HEAD alike.
+ * fetch() resolves on headers, so reading only the status costs ~50ms even for an
+ * 18 MB file, and the body is dropped rather than read.
+ */
+export async function checkEngineAssetReachable(
+  engine: EngineName,
+  baseUrl: string,
+): Promise<string | null> {
+  const url = baseUrl + CORE_WASM[engine];
+  let response: Response;
+  try {
+    response = await fetch(url);
+  } catch (e) {
+    // Offline or DNS failure: no status to report.
+    return `The ${
+      ENGINE_LABEL[engine]
+    } engine could not be downloaded. ${url} is unreachable (${
+      e instanceof Error ? e.message : String(e)
+    }).`;
+  }
+
+  // Only the status was needed; releasing the body is best-effort.
+  try {
+    await response.body?.cancel();
+  } catch {
+    /* already released */
+  }
+
+  if (!response.ok) {
+    return `The ${ENGINE_LABEL[engine]} engine could not be downloaded. ${url} returned HTTP ${response.status}.`;
+  }
+  return null;
+}

--- a/src/hooks/useLoadStatus.ts
+++ b/src/hooks/useLoadStatus.ts
@@ -1,3 +1,4 @@
+// Subscribes a component to one engine's load status, re-rendering on each stage.
 import { useSyncExternalStore } from "react";
 import type { EngineName, LoadStatus } from "../load-status";
 import { loadStatusStore } from "../load-status";

--- a/src/hooks/useLoadStatus.ts
+++ b/src/hooks/useLoadStatus.ts
@@ -1,0 +1,9 @@
+import { useSyncExternalStore } from "react";
+import type { EngineName, LoadStatus } from "../load-status";
+import { loadStatusStore } from "../load-status";
+
+export function useLoadStatus(engine: EngineName): LoadStatus {
+  const store = loadStatusStore(engine);
+  // get() doubles as getServerSnapshot; it has no browser-only dependencies.
+  return useSyncExternalStore(store.subscribe, store.get, store.get);
+}

--- a/src/hooks/usePyodide.tsx
+++ b/src/hooks/usePyodide.tsx
@@ -50,7 +50,6 @@ export async function initPyodide({
   if (unreachable) throw new Error(unreachable);
 
   const pyodideProxy = await loadPyodideProxy(
-    // indexURL is Pyodide's own loadPyodide() parameter name; keep it as-is.
     { type: proxyType, indexURL: baseUrl },
     stdout,
     stderr,
@@ -144,8 +143,8 @@ export function usePyodide({
       const pyodideProxyHandle = await pyodideProxyHandlePromise;
       setPyodideProxyHandle(pyodideProxyHandle);
     })().catch((e) => {
-      // Already surfaced to the user via the load status store; log it so it
-      // isn't an unhandled rejection.
+      // Already surfaced to the user via the load status store;
+      // logged to console so it isn't an unhandled rejection.
       console.error(e);
     });
   }, [pyodideProxyHandlePromise]);

--- a/src/hooks/usePyodide.tsx
+++ b/src/hooks/usePyodide.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from "react";
+import { loadStatusStore } from "../load-status";
 import type { ProxyType, PyodideProxy } from "../pyodide-proxy";
 import { loadPyodideProxy } from "../pyodide-proxy";
 import * as utils from "../utils";
@@ -36,6 +37,9 @@ export async function initPyodide({
   if (!stdout) stdout = async (x: string) => console.log("pyodide echo:" + x);
   if (!stderr) stderr = (x: string) => console.error("pyodide error:" + x);
 
+  const status = loadStatusStore("python");
+
+  status.set("engine-download");
   const pyodideProxy = await loadPyodideProxy(
     {
       type: proxyType,
@@ -47,10 +51,15 @@ export async function initPyodide({
 
   let initError = false;
   try {
-    // One-time initialization of Python session
+    // One-time initialization of Python session. This await also loads the base
+    // packages, since the worker calls loadPackagesFromImports before running
+    // the code, so boot and package loading are reported as a single stage.
+    status.set("engine-start");
     await pyodideProxy.runPyAsync(load_python_pre);
+    status.set("ready");
   } catch (e) {
     initError = true;
+    status.set("failed", e instanceof Error ? e.message : String(e));
     console.error(e);
   }
 
@@ -127,7 +136,11 @@ export function usePyodide({
     (async () => {
       const pyodideProxyHandle = await pyodideProxyHandlePromise;
       setPyodideProxyHandle(pyodideProxyHandle);
-    })();
+    })().catch((e) => {
+      // Already surfaced to the user via the load status store; log it so it
+      // isn't an unhandled rejection.
+      console.error(e);
+    });
   }, [pyodideProxyHandlePromise]);
 
   return pyodideProxyHandle;

--- a/src/hooks/usePyodide.tsx
+++ b/src/hooks/usePyodide.tsx
@@ -40,17 +40,18 @@ export async function initPyodide({
 
   const status = loadStatusStore("python");
 
-  const indexURL = utils.currentScriptDir() + "/pyodide/";
+  const baseUrl = utils.currentScriptDir() + "/pyodide/";
 
   status.set("engine-download");
   // Checked because loadPyodide() hangs rather than failing when the wasm is
   // missing; see engine-load-guard.ts. This throw propagates to App.tsx, which
   // records it as "failed".
-  const unreachable = await checkEngineAssetReachable("python", indexURL);
+  const unreachable = await checkEngineAssetReachable("python", baseUrl);
   if (unreachable) throw new Error(unreachable);
 
   const pyodideProxy = await loadPyodideProxy(
-    { type: proxyType, indexURL },
+    // indexURL is Pyodide's own loadPyodide() parameter name; keep it as-is.
+    { type: proxyType, indexURL: baseUrl },
     stdout,
     stderr,
   );

--- a/src/hooks/usePyodide.tsx
+++ b/src/hooks/usePyodide.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from "react";
+import { checkEngineAssetReachable } from "../engine-load-guard";
 import { loadStatusStore } from "../load-status";
 import type { ProxyType, PyodideProxy } from "../pyodide-proxy";
 import { loadPyodideProxy } from "../pyodide-proxy";
@@ -39,12 +40,17 @@ export async function initPyodide({
 
   const status = loadStatusStore("python");
 
+  const indexURL = utils.currentScriptDir() + "/pyodide/";
+
   status.set("engine-download");
+  // Checked because loadPyodide() hangs rather than failing when the wasm is
+  // missing; see engine-load-guard.ts. This throw propagates to App.tsx, which
+  // records it as "failed".
+  const unreachable = await checkEngineAssetReachable("python", indexURL);
+  if (unreachable) throw new Error(unreachable);
+
   const pyodideProxy = await loadPyodideProxy(
-    {
-      type: proxyType,
-      indexURL: utils.currentScriptDir() + "/pyodide/",
-    },
+    { type: proxyType, indexURL },
     stdout,
     stderr,
   );

--- a/src/hooks/useWebR.tsx
+++ b/src/hooks/useWebR.tsx
@@ -133,8 +133,8 @@ export function useWebR({
       const webRProxyHandle = await webRProxyHandlePromise;
       setwebRProxyHandle(webRProxyHandle);
     })().catch((e) => {
-      // Already surfaced to the user via the load status store; log it so it
-      // isn't an unhandled rejection.
+      // Already surfaced to the user via the load status store;
+      // logged to the console so it isn't an unhandled rejection.
       console.error(e);
     });
   }, [webRProxyHandlePromise]);
@@ -346,28 +346,19 @@ webr::shim_install()
 # on to display an app that never started. Returning the failure as a value is
 # what makes a failed startup visible.
 #
-# A status list rather than the message alone: a condition whose message is
-# empty is indistinguishable from success once the two share one string, and
-# conditionMessage() on its own throws away the condition's call, so the viewer
-# could say what failed but not which call failed.
+# The status field carries the explicit outcome rather than leaving it to be inferred: a
+# condition can carry an empty message, which on its own would read as success.
+# The class and call fields are what conditionMessage() would drop, and the call
+# is how the dialog can name which call failed, not just what went wrong.
 .start_app <- function(appName, appDir, devMode = FALSE) {
   tryCatch(
     {
-      # Parse the app's R files before shiny does. shiny's sourceUTF8 catches the
-      # parse error and raises only "Error sourcing <file>", discarding the line
-      # number and the offending line, so letting parse() fail here is what gets
-      # that detail to the viewer. Runs first so a typo fails before any package
-      # installs rather than after them.
-      #
-      # Reporting the condition's call below does not replace this step: the
-      # detail is destroyed by sourceUTF8's own try() before any handler of ours
-      # sees a condition, so there is nothing left for one to report.
+      # Perform a basic parse of top-level R scripts to highlight any syntax
+      # errors. Runs first so a typo fails before spending time on package installs.
       for (f in list.files(appDir, pattern = "[.][Rr]$", full.names = TRUE)) {
         # call. = FALSE because the call this condition would otherwise carry is
         # this loop's own parse(file = f), whose f names nothing an app author
-        # would recognise. conditionMessage() keeps the whole reason the step
-        # exists: the file, the line and column, the offending source lines and
-        # the caret.
+        # would recognise.
         tryCatch(
           parse(file = f),
           error = function(cnd) stop(conditionMessage(cnd), call. = FALSE)
@@ -388,7 +379,7 @@ webr::shim_install()
         if (!has_pkg) {
           # Deliberately not fatal: renv::dependencies() also reports packages
           # that are named but never actually used, and those apps run fine
-          # today. A package that really is needed fails below, when the app
+          # today. A package that really is needed fails later, when the app
           # source is evaluated.
           webr::install(pkg_name)
         }
@@ -418,8 +409,7 @@ webr::shim_install()
         # shiny wraps every app body in ..stacktraceon..(), so for any top-level
         # failure the condition's call is the whole app source -- no use to anyone
         # reading the dialog. Report a call only when it names something the
-        # author would recognise, and fall back to the bare message otherwise,
-        # which is what the dialog showed before it reported a call at all.
+        # author would recognize, and fall back to the bare message otherwise.
         #
         # A prefix rather than a list of names: the shiny shipped here exports
         # ..stacktraceon.. and ..stacktraceoff.., and the prefix covers both

--- a/src/hooks/useWebR.tsx
+++ b/src/hooks/useWebR.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import { ChannelType } from "webr";
+import { loadStatusStore } from "../load-status";
 import * as utils from "../utils";
 import type { WebRProxy } from "../webr-proxy";
 import { loadWebRProxy } from "../webr-proxy";
@@ -38,6 +39,9 @@ export async function initWebR({
     : ChannelType.PostMessage;
   const baseUrl = utils.currentScriptDir() + "/webr/";
 
+  const status = loadStatusStore("r");
+
+  status.set("engine-download");
   const webRProxy = await loadWebRProxy(
     {
       baseUrl,
@@ -49,13 +53,16 @@ export async function initWebR({
 
   let initError = false;
   try {
+    status.set("engine-start");
     await webRProxy.webR.objs.globalEnv.bind(".base_url", baseUrl);
     await webRProxy.runRAsync(
       `webr::mount("/shinylive/library", "${baseUrl}library.data.gz")`,
     );
     await webRProxy.runRAsync(load_r_pre);
+    status.set("ready");
   } catch (e) {
     initError = true;
+    status.set("failed", e instanceof Error ? e.message : String(e));
     console.error(e);
   }
 
@@ -121,7 +128,11 @@ export function useWebR({
     (async () => {
       const webRProxyHandle = await webRProxyHandlePromise;
       setwebRProxyHandle(webRProxyHandle);
-    })();
+    })().catch((e) => {
+      // Already surfaced to the user via the load status store; log it so it
+      // isn't an unhandled rejection.
+      console.error(e);
+    });
   }, [webRProxyHandlePromise]);
 
   return webRProxyHandle;

--- a/src/hooks/useWebR.tsx
+++ b/src/hooks/useWebR.tsx
@@ -400,14 +400,23 @@ webr::shim_install()
       if (!nzchar(msg)) msg <- "The app failed to start, with no error message."
       # conditionCall() is NULL when the condition was signalled without a call,
       # and deparse() returns one element per line of source. Keep only the first
-      # line, marking that there was more, the way R's own error printing does:
-      # shiny evaluates the app's body inside ..stacktraceon..(), so deparsing
-      # that call in full would put the entire app source in the dialog.
+      # line, marking that there was more, the way R's own error printing does,
+      # so that a long but meaningful call is trimmed rather than dumped.
       cnd_call <- conditionCall(cnd)
       call_txt <- ""
       if (!is.null(cnd_call)) {
         lines <- deparse(cnd_call)
         call_txt <- if (length(lines) > 1) paste0(lines[[1]], " ...") else lines[[1]]
+        # shiny wraps every app body in ..stacktraceon..(), so for any top-level
+        # failure the condition's call is the whole app source -- no use to anyone
+        # reading the dialog. Report a call only when it names something the
+        # author would recognise, and fall back to the bare message otherwise,
+        # which is what the dialog showed before it reported a call at all.
+        #
+        # A prefix rather than a list of names: the shiny shipped here exports
+        # ..stacktraceon.. and ..stacktraceoff.., and the prefix covers both
+        # without naming internals that may not exist in a given shiny.
+        if (startsWith(call_txt, "..stacktrace")) call_txt <- ""
       }
       list(status = "error", message = msg, class = class(cnd), call = call_txt)
     }

--- a/src/hooks/useWebR.tsx
+++ b/src/hooks/useWebR.tsx
@@ -363,7 +363,15 @@ webr::shim_install()
       # detail is destroyed by sourceUTF8's own try() before any handler of ours
       # sees a condition, so there is nothing left for one to report.
       for (f in list.files(appDir, pattern = "[.][Rr]$", full.names = TRUE)) {
-        parse(file = f)
+        # call. = FALSE because the call this condition would otherwise carry is
+        # this loop's own parse(file = f), whose f names nothing an app author
+        # would recognise. conditionMessage() keeps the whole reason the step
+        # exists: the file, the line and column, the offending source lines and
+        # the caret.
+        tryCatch(
+          parse(file = f),
+          error = function(cnd) stop(conditionMessage(cnd), call. = FALSE)
+        )
       }
 
       # Mount VFS images provided in Shinylive app assets

--- a/src/hooks/useWebR.tsx
+++ b/src/hooks/useWebR.tsx
@@ -348,6 +348,15 @@ webr::shim_install()
 .start_app <- function(appName, appDir, devMode = FALSE) {
   tryCatch(
     {
+      # Parse the app's R files before shiny does. shiny's sourceUTF8 catches the
+      # parse error and raises only "Error sourcing <file>", discarding the line
+      # number and the offending line, so letting parse() fail here is what gets
+      # that detail to the viewer. Runs first so a typo fails before any package
+      # installs rather than after them.
+      for (f in list.files(appDir, pattern = "[.][Rr]$", full.names = TRUE)) {
+        parse(file = f)
+      }
+
       # Mount VFS images provided in Shinylive app assets
       .mount_vfs_images()
 

--- a/src/hooks/useWebR.tsx
+++ b/src/hooks/useWebR.tsx
@@ -408,8 +408,8 @@ webr::shim_install()
       if (!nzchar(msg)) msg <- "The app failed to start, with no error message."
       # conditionCall() is NULL when the condition was signalled without a call,
       # and deparse() returns one element per line of source. Keep only the first
-      # line, marking that there was more, the way R's own error printing does,
-      # so that a long but meaningful call is trimmed rather than dumped.
+      # line, marking that there was more, so that a long but meaningful call is
+      # trimmed rather than dumped.
       cnd_call <- conditionCall(cnd)
       call_txt <- ""
       if (!is.null(cnd_call)) {

--- a/src/hooks/useWebR.tsx
+++ b/src/hooks/useWebR.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import { ChannelType } from "webr";
+import { checkEngineAssetReachable } from "../engine-load-guard";
 import { loadStatusStore } from "../load-status";
 import * as utils from "../utils";
 import type { WebRProxy } from "../webr-proxy";
@@ -42,11 +43,14 @@ export async function initWebR({
   const status = loadStatusStore("r");
 
   status.set("engine-download");
+  // Checked because webR's init() hangs rather than failing when the wasm is
+  // missing; see engine-load-guard.ts. This throw propagates to App.tsx, which
+  // records it as "failed".
+  const unreachable = await checkEngineAssetReachable("r", baseUrl);
+  if (unreachable) throw new Error(unreachable);
+
   const webRProxy = await loadWebRProxy(
-    {
-      baseUrl,
-      channelType,
-    },
+    { baseUrl, channelType },
     stdout,
     stderr,
   );
@@ -335,31 +339,50 @@ webr::shim_install()
   lapply(rownames(installed.packages()), function(p) { .webr_pkg_cache[[p]] <<- TRUE })
 }
 
+# Returns "" on success, or the error message on failure.
+#
+# The caller evaluates this with captureConditions = FALSE, so an error raised
+# here would go to the terminal and never reach JavaScript: the viewer would go
+# on to display an app that never started. Returning the message instead is what
+# makes a failed startup visible.
 .start_app <- function(appName, appDir, devMode = FALSE) {
-  # Mount VFS images provided in Shinylive app assets
-  .mount_vfs_images()
+  tryCatch(
+    {
+      # Mount VFS images provided in Shinylive app assets
+      .mount_vfs_images()
 
-  # Uniquely install packages with webr
-  unique_pkgs <- unique(renv::dependencies(appDir, quiet = TRUE)$Package)
-  lapply(unique_pkgs, function(pkg_name) {
-    if (isTRUE(.webr_pkg_cache[[pkg_name]])) return()
+      # Uniquely install packages with webr
+      unique_pkgs <- unique(renv::dependencies(appDir, quiet = TRUE)$Package)
+      lapply(unique_pkgs, function(pkg_name) {
+        if (isTRUE(.webr_pkg_cache[[pkg_name]])) return()
 
-    has_pkg <- nzchar(system.file(package = pkg_name))
-    .webr_pkg_cache[[pkg_name]] <<- has_pkg
+        has_pkg <- nzchar(system.file(package = pkg_name))
+        .webr_pkg_cache[[pkg_name]] <<- has_pkg
 
-    if (!has_pkg) {
-      webr::install(pkg_name)
+        if (!has_pkg) {
+          # Deliberately not fatal: renv::dependencies() also reports packages
+          # that are named but never actually used, and those apps run fine
+          # today. A package that really is needed fails below, when the app
+          # source is evaluated.
+          webr::install(pkg_name)
+        }
+      })
+
+      if (isTRUE(devMode)) {
+        # Enable client-side dev mode features, namely the error console
+        options(shiny.client_devmode = TRUE)
+      }
+
+      app <- .shiny_to_httpuv(appDir)
+      assign(appName, app, envir = .shiny_app_registry)
+      ""
+    },
+    error = function(cnd) {
+      msg <- paste(conditionMessage(cnd), collapse = "\n")
+      if (!nzchar(msg)) msg <- "The app failed to start, with no error message."
+      msg
     }
-  })
-
-  if (isTRUE(devMode)) {
-    # Enable client-side dev mode features, namely the error console
-    options(shiny.client_devmode = TRUE)
-  }
-
-  app <- .shiny_to_httpuv(appDir)
-  assign(appName, app, envir = .shiny_app_registry)
-  invisible(0)
+  )
 }
 
 invisible(0)

--- a/src/hooks/useWebR.tsx
+++ b/src/hooks/useWebR.tsx
@@ -339,12 +339,17 @@ webr::shim_install()
   lapply(rownames(installed.packages()), function(p) { .webr_pkg_cache[[p]] <<- TRUE })
 }
 
-# Returns "" on success, or the error message on failure.
+# Returns list(status = "ok"), or list(status = "error", message, class, call).
 #
 # The caller evaluates this with captureConditions = FALSE, so an error raised
 # here would go to the terminal and never reach JavaScript: the viewer would go
-# on to display an app that never started. Returning the message instead is what
-# makes a failed startup visible.
+# on to display an app that never started. Returning the failure as a value is
+# what makes a failed startup visible.
+#
+# A status list rather than the message alone: a condition whose message is
+# empty is indistinguishable from success once the two share one string, and
+# conditionMessage() on its own throws away the condition's call, so the viewer
+# could say what failed but not which call failed.
 .start_app <- function(appName, appDir, devMode = FALSE) {
   tryCatch(
     {
@@ -353,6 +358,10 @@ webr::shim_install()
       # number and the offending line, so letting parse() fail here is what gets
       # that detail to the viewer. Runs first so a typo fails before any package
       # installs rather than after them.
+      #
+      # Reporting the condition's call below does not replace this step: the
+      # detail is destroyed by sourceUTF8's own try() before any handler of ours
+      # sees a condition, so there is nothing left for one to report.
       for (f in list.files(appDir, pattern = "[.][Rr]$", full.names = TRUE)) {
         parse(file = f)
       }
@@ -384,12 +393,23 @@ webr::shim_install()
 
       app <- .shiny_to_httpuv(appDir)
       assign(appName, app, envir = .shiny_app_registry)
-      ""
+      list(status = "ok")
     },
     error = function(cnd) {
       msg <- paste(conditionMessage(cnd), collapse = "\n")
       if (!nzchar(msg)) msg <- "The app failed to start, with no error message."
-      msg
+      # conditionCall() is NULL when the condition was signalled without a call,
+      # and deparse() returns one element per line of source. Keep only the first
+      # line, marking that there was more, the way R's own error printing does:
+      # shiny evaluates the app's body inside ..stacktraceon..(), so deparsing
+      # that call in full would put the entire app source in the dialog.
+      cnd_call <- conditionCall(cnd)
+      call_txt <- ""
+      if (!is.null(cnd_call)) {
+        lines <- deparse(cnd_call)
+        call_txt <- if (length(lines) > 1) paste0(lines[[1]], " ...") else lines[[1]]
+      }
+      list(status = "error", message = msg, class = class(cnd), call = call_txt)
     }
   )
 }

--- a/src/load-status.test.ts
+++ b/src/load-status.test.ts
@@ -132,10 +132,10 @@ describe("failed is terminal", () => {
   });
 
   test("a non-failed set() followed by a second failed() both leave the first error in place", () => {
-    // Regression test for Fix 1: on the R path, initRShiny's `library(shiny)`
-    // failure used to overwrite the real root-cause error because a spurious
-    // "ready" transition slipped through in between the two set("failed", ...)
-    // calls. Exercise that exact sequence: failed -> ready -> failed(second).
+    // The general form of the two above: nothing reopens a failed store. That
+    // matters on the R path, where initWebR records the root cause but returns
+    // `ready: true` anyway, so App.tsx goes on to initRShiny and `library(shiny)`
+    // fails downstream — an error that would otherwise replace the real one.
     const store = loadStatusStore("python");
     store.set("failed", "first");
     store.set("ready");

--- a/src/load-status.test.ts
+++ b/src/load-status.test.ts
@@ -1,0 +1,197 @@
+import { loadStatusStore, resetLoadStatusStores } from "./load-status";
+
+beforeEach(() => {
+  resetLoadStatusStores();
+});
+
+describe("initial state", () => {
+  test("starts idle with no error", () => {
+    const store = loadStatusStore("python");
+    expect(store.get()).toEqual({ stage: "idle", error: null });
+  });
+});
+
+describe("set()", () => {
+  test("set() advances the stage", () => {
+    const store = loadStatusStore("python");
+    store.set("engine-download");
+    expect(store.get().stage).toBe("engine-download");
+  });
+
+  test("set() records an error message", () => {
+    const store = loadStatusStore("python");
+    store.set("failed", "boom");
+    expect(store.get()).toEqual({ stage: "failed", error: "boom" });
+  });
+
+  test("set() without an error clears any previous error", () => {
+    const store = loadStatusStore("python");
+    // "failed" is terminal (see below), so use a non-terminal stage here to
+    // exercise the unrelated error-clearing behavior of set().
+    store.set("engine-download", "transient message");
+    store.set("engine-start");
+    expect(store.get().error).toBeNull();
+  });
+
+  test("set('failed') with no message records a null error, not undefined", () => {
+    // Viewer renders this straight into a <pre>; undefined would print nothing
+    // while null at least keeps the element empty and predictable.
+    const store = loadStatusStore("python");
+    store.set("failed");
+    expect(store.get()).toEqual({ stage: "failed", error: null });
+  });
+});
+
+describe("subscription", () => {
+  test("subscribers are notified on change", () => {
+    const store = loadStatusStore("python");
+    const seen = jest.fn();
+    store.subscribe(seen);
+    store.set("engine-download");
+    expect(seen).toHaveBeenCalledTimes(1);
+  });
+
+  test("unsubscribe stops notifications", () => {
+    const store = loadStatusStore("python");
+    const seen = jest.fn();
+    const unsubscribe = store.subscribe(seen);
+    unsubscribe();
+    store.set("engine-download");
+    expect(seen).not.toHaveBeenCalled();
+  });
+
+  test("setting the same state does not notify (useSyncExternalStore safety)", () => {
+    // useSyncExternalStore re-renders on every notification, so an unchanged
+    // state must not notify at all.
+    const store = loadStatusStore("python");
+    store.set("engine-download");
+    const seen = jest.fn();
+    store.subscribe(seen);
+    store.set("engine-download");
+    expect(seen).not.toHaveBeenCalled();
+  });
+
+  test("get() returns a stable reference until state changes (useSyncExternalStore safety)", () => {
+    // Stable reference: useSyncExternalStore loops forever if get() returns a
+    // fresh object on every call while the state is unchanged.
+    const store = loadStatusStore("python");
+    const first = store.get();
+    expect(store.get()).toBe(first);
+    store.set("engine-start");
+    expect(store.get()).not.toBe(first);
+  });
+});
+
+describe("per-engine stores", () => {
+  test("the same engine returns the same store instance", () => {
+    expect(loadStatusStore("python")).toBe(loadStatusStore("python"));
+  });
+
+  test("engines are isolated: python updates do not notify r", () => {
+    const python = loadStatusStore("python");
+    const r = loadStatusStore("r");
+    const rSeen = jest.fn();
+    r.subscribe(rSeen);
+    python.set("engine-download");
+    expect(rSeen).not.toHaveBeenCalled();
+    expect(r.get().stage).toBe("idle");
+  });
+
+  test("engines fail independently, each keeping its own error", () => {
+    const python = loadStatusStore("python");
+    const r = loadStatusStore("r");
+    python.set("failed", "pyodide is gone");
+    r.set("failed", "webR is gone");
+    expect(python.get().error).toBe("pyodide is gone");
+    expect(r.get().error).toBe("webR is gone");
+  });
+
+  test("one engine failing leaves the other free to reach ready", () => {
+    const python = loadStatusStore("python");
+    const r = loadStatusStore("r");
+    python.set("failed", "boom");
+    r.set("ready");
+    expect(python.get().stage).toBe("failed");
+    expect(r.get().stage).toBe("ready");
+  });
+});
+
+describe("failed is terminal", () => {
+  test("a later set() does not change stage or error", () => {
+    const store = loadStatusStore("python");
+    store.set("failed", "root cause");
+    store.set("failed", "secondary failure");
+    expect(store.get()).toEqual({ stage: "failed", error: "root cause" });
+  });
+
+  test("even a set() to a non-failed stage is ignored", () => {
+    const store = loadStatusStore("python");
+    store.set("failed", "root cause");
+    store.set("ready");
+    expect(store.get()).toEqual({ stage: "failed", error: "root cause" });
+  });
+
+  test("a non-failed set() followed by a second failed() both leave the first error in place", () => {
+    // Regression test for Fix 1: on the R path, initRShiny's `library(shiny)`
+    // failure used to overwrite the real root-cause error because a spurious
+    // "ready" transition slipped through in between the two set("failed", ...)
+    // calls. Exercise that exact sequence: failed -> ready -> failed(second).
+    const store = loadStatusStore("python");
+    store.set("failed", "first");
+    store.set("ready");
+    expect(store.get()).toEqual({ stage: "failed", error: "first" });
+    store.set("failed", "second");
+    expect(store.get()).toEqual({ stage: "failed", error: "first" });
+  });
+});
+
+describe("realistic sequences", () => {
+  test("a realistic engine-load failure: idle -> engine-download -> failed", () => {
+    const store = loadStatusStore("python");
+    const seen: string[] = [];
+    store.subscribe(() => seen.push(store.get().stage));
+    store.set("engine-download");
+    store.set("failed", "Failed to fetch pyodide.asm.wasm");
+    expect(seen).toEqual(["engine-download", "failed"]);
+    expect(store.get()).toEqual({
+      stage: "failed",
+      error: "Failed to fetch pyodide.asm.wasm",
+    });
+  });
+
+  test("failing after ready is still recorded (app-start failures come later)", () => {
+    // The engine reaching "ready" does not mean the app will start: requirements
+    // installation and app import both happen afterwards. A failure then must
+    // still register, or Viewer would never show the error alert.
+    const store = loadStatusStore("python");
+    store.set("engine-download");
+    store.set("engine-start");
+    store.set("ready");
+    store.set("failed", "ModuleNotFoundError");
+    expect(store.get()).toEqual({
+      stage: "failed",
+      error: "ModuleNotFoundError",
+    });
+  });
+
+  test("a multi-line traceback is preserved verbatim", () => {
+    // Viewer renders store.error inside a <pre>, so newlines and indentation are
+    // load-bearing and must not be normalized on the way through.
+    const traceback =
+      'Traceback (most recent call last):\n  File "app.py", line 4\n    ui.p("x")\n    ^^\nSyntaxError: invalid syntax';
+    const store = loadStatusStore("python");
+    store.set("failed", traceback);
+    expect(store.get().error).toBe(traceback);
+  });
+});
+
+describe("resetLoadStatusStores()", () => {
+  test("discards existing stores", () => {
+    const before = loadStatusStore("python");
+    before.set("ready");
+    resetLoadStatusStores();
+    const after = loadStatusStore("python");
+    expect(after).not.toBe(before);
+    expect(after.get().stage).toBe("idle");
+  });
+});

--- a/src/load-status.test.ts
+++ b/src/load-status.test.ts
@@ -161,8 +161,11 @@ describe("realistic sequences", () => {
 
   test("failing after ready is still recorded (app-start failures come later)", () => {
     // The engine reaching "ready" does not mean the app will start: requirements
-    // installation and app import both happen afterwards. A failure then must
-    // still register, or Viewer would never show the error alert.
+    // installation and app import both happen afterwards, but at the engine
+    // level -- an app-start failure travels through Viewer's own
+    // lastErrorMessage/appRunningState instead, not this store. Nothing here
+    // special-cases "ready", so a late engine-level failure is recorded rather
+    // than silently dropped.
     const store = loadStatusStore("python");
     store.set("engine-download");
     store.set("engine-start");

--- a/src/load-status.ts
+++ b/src/load-status.ts
@@ -1,0 +1,80 @@
+// Observable store for Wasm engine (Pyodide / webR) load progress.
+//
+// Module-level rather than React state because engine initialization starts
+// before any component mounts, so no prop or context can carry the early stages.
+//
+// One store per engine rather than one global store, because a page can mix
+// Python and R blocks and run both engines at once.
+
+// Declared here rather than imported from ./Components/App, to avoid a circular
+// import.
+export type EngineName = "python" | "r";
+
+export type LoadStage =
+  | "idle"
+  | "engine-download" // fetching and compiling the wasm runtime
+  | "engine-start" // interpreter boot and base packages
+  | "ready"
+  | "failed";
+
+export type LoadStatus = {
+  stage: LoadStage;
+  error: string | null;
+};
+
+export type LoadStatusStore = {
+  get: () => LoadStatus;
+  set: (stage: LoadStage, error?: string) => void;
+  subscribe: (onChange: () => void) => () => void;
+};
+
+// Shared so LoadingStatus and Viewer cannot drift apart.
+export const ENGINE_LABEL: Record<EngineName, string> = {
+  python: "Python",
+  r: "R",
+};
+
+const IDLE: LoadStatus = { stage: "idle", error: null };
+
+function createLoadStatusStore(): LoadStatusStore {
+  let status: LoadStatus = IDLE;
+  const listeners = new Set<() => void>();
+
+  return {
+    // Stable reference: useSyncExternalStore loops forever if this returns a
+    // fresh object on every call.
+    get: () => status,
+
+    set: (stage: LoadStage, error?: string) => {
+      // Terminal, so a later failure cannot overwrite the original cause.
+      if (status.stage === "failed") return;
+      const nextError = error ?? null;
+      if (status.stage === stage && status.error === nextError) return;
+      status = { stage, error: nextError };
+      listeners.forEach((listener) => listener());
+    },
+
+    subscribe: (onChange: () => void) => {
+      listeners.add(onChange);
+      return () => {
+        listeners.delete(onChange);
+      };
+    },
+  };
+}
+
+const stores = new Map<EngineName, LoadStatusStore>();
+
+export function loadStatusStore(engine: EngineName): LoadStatusStore {
+  let store = stores.get(engine);
+  if (!store) {
+    store = createLoadStatusStore();
+    stores.set(engine, store);
+  }
+  return store;
+}
+
+// Test seam; nothing in the app calls this.
+export function resetLoadStatusStores(): void {
+  stores.clear();
+}

--- a/src/pyodide-proxy.ts
+++ b/src/pyodide-proxy.ts
@@ -381,10 +381,19 @@ class WebWorkerPyodideProxy implements PyodideProxy {
   }
 
   async init(config: LoadPyodideConfig): Promise<void> {
-    await this.postMessageAsync({
+    const response = (await this.postMessageAsync({
       type: "init",
       config,
-    });
+    })) as PyodideWorker.ReplyMessageDone;
+
+    // The worker reports an init failure in the reply rather than by dying, so
+    // without this check a Pyodide that never started looks like one that did,
+    // and the first symptom is an unrelated error much later.
+    if (response.error) {
+      const err = postableErrorObjectToError(response.error);
+      this.stderrCallback(err.message);
+      throw err;
+    }
   }
 
   proxyType(): ProxyType {

--- a/src/pyodide-worker.ts
+++ b/src/pyodide-worker.ts
@@ -239,7 +239,10 @@ self.onmessage = async function (e: MessageEvent): Promise<void> {
       });
     }
   } catch (e) {
-    if (e instanceof pyodide.ffi.PythonError) {
+    if (
+      typeof pyodide !== "undefined" &&
+      e instanceof pyodide.ffi.PythonError
+    ) {
       e.message = pyUtils.shortFormatLastTraceback();
     }
 

--- a/src/pyodide-worker.ts
+++ b/src/pyodide-worker.ts
@@ -247,10 +247,8 @@ self.onmessage = async function (e: MessageEvent): Promise<void> {
       });
     }
   } catch (e) {
-    // Both of these can still be undefined here: init may have failed partway
-    // through, after loadPyodide() but before setupPythonEnv() returned. If we
-    // throw from this handler, no reply is ever posted and the caller waits
-    // forever, so it must not assume either one exists.
+    // pyUtils can still be undefined here if init failed before
+    // setupPythonEnv() returned.
     if (
       typeof pyodide !== "undefined" &&
       typeof pyUtils !== "undefined" &&

--- a/src/pyodide-worker.ts
+++ b/src/pyodide-worker.ts
@@ -131,15 +131,23 @@ self.onmessage = async function (e: MessageEvent): Promise<void> {
       if (pyodideStatus === "none") {
         pyodideStatus = "loading";
 
-        pyodide = await loadPyodide({
-          ...msg.config,
-          stdout: self.stdout_callback,
-          stderr: self.stderr_callback,
-        });
+        try {
+          pyodide = await loadPyodide({
+            ...msg.config,
+            stdout: self.stdout_callback,
+            stderr: self.stderr_callback,
+          });
 
-        pyUtils = await setupPythonEnv(pyodide, callJS);
+          pyUtils = await setupPythonEnv(pyodide, callJS);
 
-        pyodideStatus = "loaded";
+          pyodideStatus = "loaded";
+        } catch (e) {
+          // Reset the status so that a subsequent init starts over. Otherwise
+          // it would take the "already loading/loaded" path and report success
+          // with a pyodide that was never initialized.
+          pyodideStatus = "none";
+          throw e;
+        }
       }
 
       messagePort.postMessage({ type: "reply", subtype: "done" });
@@ -239,8 +247,13 @@ self.onmessage = async function (e: MessageEvent): Promise<void> {
       });
     }
   } catch (e) {
+    // Both of these can still be undefined here: init may have failed partway
+    // through, after loadPyodide() but before setupPythonEnv() returned. If we
+    // throw from this handler, no reply is ever posted and the caller waits
+    // forever, so it must not assume either one exists.
     if (
       typeof pyodide !== "undefined" &&
+      typeof pyUtils !== "undefined" &&
       e instanceof pyodide.ffi.PythonError
     ) {
       e.message = pyUtils.shortFormatLastTraceback();

--- a/src/r-status.test.ts
+++ b/src/r-status.test.ts
@@ -58,9 +58,9 @@ describe("reading a field", () => {
 // would land here, and nothing else in either suite would notice.
 describe("an unreadable reply gives no values rather than a guess", () => {
   test("no names at all", () => {
-    expect(rCharacterField({ type: "null" } as unknown as Js, "status")).toEqual(
-      [],
-    );
+    expect(
+      rCharacterField({ type: "null" } as unknown as Js, "status"),
+    ).toEqual([]);
   });
 
   test("names is null", () => {

--- a/src/r-status.test.ts
+++ b/src/r-status.test.ts
@@ -1,0 +1,119 @@
+import { rCharacterField } from "./r-status";
+
+// webR's `toJs()` shape, built by hand. The real thing comes back from the
+// worker, so these stand in for what it sends: an R list is a
+// `{ type, names, values }` node, and each element is either another such node
+// or an already-unwrapped scalar.
+type Js = Parameters<typeof rCharacterField>[0];
+
+function node(names: string[], values: unknown[]): Js {
+  return { type: "list", names, values } as unknown as Js;
+}
+
+function chr(...values: string[]) {
+  return { type: "character", names: null, values };
+}
+
+describe("reading a field", () => {
+  test("a character element gives its values", () => {
+    const js = node(["status"], [chr("ok")]);
+    expect(rCharacterField(js, "status")).toEqual(["ok"]);
+  });
+
+  test("an already-unwrapped scalar is taken as-is", () => {
+    // webr's WebRDataJsNode.values is typed as holding either, so both the
+    // wrapped and the bare form have to work.
+    const js = node(["status"], ["ok"]);
+    expect(rCharacterField(js, "status")).toEqual(["ok"]);
+  });
+
+  test("a multi-element vector keeps every value, in order", () => {
+    // class(cnd) is a character vector, not a scalar.
+    const js = node(["class"], [chr("simpleError", "error", "condition")]);
+    expect(rCharacterField(js, "class")).toEqual([
+      "simpleError",
+      "error",
+      "condition",
+    ]);
+  });
+
+  test("the right field is read when several are present", () => {
+    const js = node(
+      ["status", "message", "call"],
+      [chr("error"), chr("boom"), chr("f()")],
+    );
+    expect(rCharacterField(js, "message")).toEqual(["boom"]);
+  });
+
+  test("non-string values in a vector are dropped", () => {
+    const js = node(["message"], [chr(...([1, "kept", null] as never[]))]);
+    expect(rCharacterField(js, "message")).toEqual(["kept"]);
+  });
+});
+
+// Each of these is a shape webR does not currently send. They matter because
+// `Viewer.tsx` reads `status` through this function: every one of them makes the
+// field read as `[]`, so `status` reads as `undefined`, and a *successful* R app
+// start reports itself as a failure. A webR upgrade that changed the node shape
+// would land here, and nothing else in either suite would notice.
+describe("an unreadable reply gives no values rather than a guess", () => {
+  test("no names at all", () => {
+    expect(rCharacterField({ type: "null" } as unknown as Js, "status")).toEqual(
+      [],
+    );
+  });
+
+  test("names is null", () => {
+    const js = { type: "character", names: null, values: ["ok"] };
+    expect(rCharacterField(js as unknown as Js, "status")).toEqual([]);
+  });
+
+  test("no values alongside the names", () => {
+    const js = { type: "list", names: ["status"] };
+    expect(rCharacterField(js as unknown as Js, "status")).toEqual([]);
+  });
+
+  test("the field is absent", () => {
+    const js = node(["message"], [chr("boom")]);
+    expect(rCharacterField(js, "status")).toEqual([]);
+  });
+
+  test("the element is null", () => {
+    const js = node(["status"], [null]);
+    expect(rCharacterField(js, "status")).toEqual([]);
+  });
+
+  test("the element is neither a string nor an object", () => {
+    const js = node(["status"], [42]);
+    expect(rCharacterField(js, "status")).toEqual([]);
+  });
+
+  test("the element is a node whose values is not an array", () => {
+    const js = node(["status"], [{ type: "character", values: "ok" }]);
+    expect(rCharacterField(js, "status")).toEqual([]);
+  });
+
+  test("the element is a node with no values at all", () => {
+    const js = node(["status"], [{ type: "character" }]);
+    expect(rCharacterField(js, "status")).toEqual([]);
+  });
+});
+
+test("the caller's success test fails on every unreadable shape", () => {
+  // The point of the block above, stated as the caller states it
+  // (Viewer.tsx: `rCharacterField(start, "status")[0] !== "ok"`). If any of
+  // these ever started reading as "ok", a reply that did not survive
+  // conversion would be treated as a successful start.
+  const unreadable: unknown[] = [
+    { type: "null" },
+    { type: "character", names: null, values: ["ok"] },
+    { type: "list", names: ["status"] },
+    node(["message"], [chr("boom")]),
+    node(["status"], [null]),
+    node(["status"], [42]),
+    node(["status"], [{ type: "character", values: "ok" }]),
+  ];
+  for (const js of unreadable) {
+    expect(rCharacterField(js as Js, "status")[0]).not.toBe("ok");
+  }
+});

--- a/src/r-status.ts
+++ b/src/r-status.ts
@@ -1,6 +1,6 @@
 import type { RObject } from "webr";
 
-/** One named character element of webR's serialisation of an R list.
+/** One named character element of webR's serialization of an R list.
  *
  * `RObject.toJs()` returns a tagged tree, not a plain object: an R list arrives
  * as `{ type, names, values }`, and each element is itself either a
@@ -13,14 +13,8 @@ import type { RObject } from "webr";
  * does not match this shape fails loudly at the caller instead of reading as
  * success.
  *
- * This lives in its own module rather than beside its caller in `Viewer.tsx` so
- * that the guards below are reachable from the jest suite. They are the ones a
- * webR upgrade would break: `Viewer.tsx` reads `status` through this function
- * too, so a shape change makes every field read as `[]`, `status` read as
- * `undefined`, and a *successful* app start report itself as a failure. The
- * pytest suite cannot cover that -- `.start_app` always returns a well-formed
- * list -- and `noUncheckedIndexedAccess` is off, so the type-checker does not
- * see it either.
+ * This lives in its own module rather than beside its caller in `Viewer.tsx` to
+ * make it unit testable.
  */
 export function rCharacterField(
   js: Awaited<ReturnType<RObject["toJs"]>>,

--- a/src/r-status.ts
+++ b/src/r-status.ts
@@ -1,0 +1,38 @@
+import type { RObject } from "webr";
+
+/** One named character element of webR's serialisation of an R list.
+ *
+ * `RObject.toJs()` returns a tagged tree, not a plain object: an R list arrives
+ * as `{ type, names, values }`, and each element is itself either a
+ * `{ type, names, values }` node or an already-unwrapped scalar -- webr's
+ * `WebRDataJsNode.values` is typed as holding either. So both levels are
+ * handled here, and the result is a `string[]` because every R character vector
+ * has a length.
+ *
+ * An absent or unreadable field gives `[]` rather than a guess, so a reply that
+ * does not match this shape fails loudly at the caller instead of reading as
+ * success.
+ *
+ * This lives in its own module rather than beside its caller in `Viewer.tsx` so
+ * that the guards below are reachable from the jest suite. They are the ones a
+ * webR upgrade would break: `Viewer.tsx` reads `status` through this function
+ * too, so a shape change makes every field read as `[]`, `status` read as
+ * `undefined`, and a *successful* app start report itself as a failure. The
+ * pytest suite cannot cover that -- `.start_app` always returns a well-formed
+ * list -- and `noUncheckedIndexedAccess` is off, so the type-checker does not
+ * see it either.
+ */
+export function rCharacterField(
+  js: Awaited<ReturnType<RObject["toJs"]>>,
+  name: string,
+): string[] {
+  if (!("names" in js) || js.names === null || !("values" in js)) return [];
+  const index = js.names.indexOf(name);
+  if (index === -1) return [];
+  const element: unknown = js.values[index];
+  if (typeof element === "string") return [element];
+  if (element === null || typeof element !== "object") return [];
+  const values: unknown = (element as { values?: unknown }).values;
+  if (!Array.isArray(values)) return [];
+  return values.filter((value): value is string => typeof value === "string");
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -144,16 +144,22 @@ And two that are simply gaps in py-shiny:
 scenario rather than assert on it, use Playwright's own tooling instead of a
 one-off script:
 
-    # Watch one, slowly, in a real window
-    pytest tests/test_loader_status.py -k "slow_load and chromium-py" \
-        --headed --slowmo 500 --loader-delay 15000
+```console
+# Watch one, slowly, in a real window
+pytest tests/test_loader_status.py -k "slow_load and chromium-py" \
+    --headed --slowmo 500 --loader-delay 15000
+```
 
-    # Record it
-    pytest tests/test_loader_status.py -k engine_setup --video on
+```console
+# Record it
+pytest tests/test_loader_status.py -k engine_setup --video on
+```
 
-    # Step through afterwards
-    pytest tests/test_loader_status.py -k app_syntax --tracing on
-    playwright show-trace test-results/**/trace.zip
+```console
+# Step through afterwards
+pytest tests/test_loader_status.py -k app_syntax --tracing on
+playwright show-trace test-results/**/trace.zip
+```
 
 Every test file's own name ends in `.py`, so a bare `-k "... and py"` selects
 both engines' parametrizations, not just Python's -- match the full

--- a/tests/README.md
+++ b/tests/README.md
@@ -138,6 +138,21 @@ And two that are simply gaps in py-shiny:
   first. py-shiny's `set()` absorbs this by inching across the track; `brush()`
   in the tests waits explicitly.
 
+## The loader tests are their own half of `site`
+
+`tests/test_loader_status.py` carries both the `site` and `loader` markers, and
+the two Make targets split on that: `make test-site` runs `-m "site and not
+loader"`, `make test-loader` runs `-m loader`. Between them they cover every
+`site` test, so running one is not running them all -- worth knowing before
+concluding the suite is green.
+
+They are split because nearly every one of them boots a real engine, which makes
+them cost about as much as all the other site tests together. `make test-site`
+runs inside the job that deploys; `make test-loader` gets a job of its own that
+does not gate the deploy. See the comment on `test-loader` in
+`.github/workflows/build.yml` for why, and for what would have to change to make
+them gate it.
+
 ## Watching a loader test by hand
 
 `tests/test_loader_status.py` replaced `scripts/loader-demo.ts`. To watch a

--- a/tests/README.md
+++ b/tests/README.md
@@ -143,21 +143,17 @@ And two that are simply gaps in py-shiny:
 `tests/test_loader_status.py` carries both the `site` and `loader` markers, and
 the two Make targets split on that: `make test-site` runs `-m "site and not
 loader"`, `make test-loader` runs `-m loader`. Between them they cover every
-`site` test, so running one is not running them all -- worth knowing before
-concluding the suite is green.
+`site` test, so running one is not running them all.
 
 They are split because nearly every one of them boots a real engine, which makes
 them cost about as much as all the other site tests together. `make test-site`
 runs inside the job that deploys; `make test-loader` gets a job of its own that
-does not gate the deploy. See the comment on `test-loader` in
-`.github/workflows/build.yml` for why, and for what would have to change to make
-them gate it.
+does not gate the deploy.
 
 ## Watching a loader test by hand
 
-`tests/test_loader_status.py` replaced `scripts/loader-demo.ts`. To watch a
-scenario rather than assert on it, use Playwright's own tooling instead of a
-one-off script:
+To watch a playwright scenario rather than just running the tests,
+you can use Playwright's tooling:
 
 ```console
 # Watch one, slowly, in a real window
@@ -177,11 +173,10 @@ playwright show-trace test-results/**/trace.zip
 ```
 
 Every test file's own name ends in `.py`, so a bare `-k "... and py"` selects
-both engines' parametrizations, not just Python's -- match the full
-parametrize id (`chromium-py`, not `py`) to get one. `--loader-delay` only
-holds back the *slow-load* test (`sabotage("off", ...)` is the only mode whose
-route handler installs the delay); it is a no-op on the failure-mode tests, so
-don't reach for it there. The status text only appears 3s after the loader
+both engines' parametrizations. `--loader-delay` only holds back the
+*slow-load* test (`sabotage("off", ...)` is the only mode whose
+route handler installs the delay); it is a no-op on the failure-mode tests.
+The status text only appears 3s after the loader
 mounts (`STATUS_DELAY_MS` in `src/Components/LoadingStatus.tsx`), so turn the
 delay up to give yourself time to read the stages. `--tracing on` overrides
 `pytest.ini`'s `--tracing retain-on-failure` and writes a trace even for a

--- a/tests/README.md
+++ b/tests/README.md
@@ -137,3 +137,32 @@ And two that are simply gaps in py-shiny:
   input for 300ms, so an action taken immediately afterwards can reach the server
   first. py-shiny's `set()` absorbs this by inching across the track; `brush()`
   in the tests waits explicitly.
+
+## Watching a loader test by hand
+
+`tests/test_loader_status.py` replaced `scripts/loader-demo.ts`. To watch a
+scenario rather than assert on it, use Playwright's own tooling instead of a
+one-off script:
+
+    # Watch one, slowly, in a real window
+    pytest tests/test_loader_status.py -k "slow_load and chromium-py" \
+        --headed --slowmo 500 --loader-delay 15000
+
+    # Record it
+    pytest tests/test_loader_status.py -k engine_setup --video on
+
+    # Step through afterwards
+    pytest tests/test_loader_status.py -k app_syntax --tracing on
+    playwright show-trace test-results/**/trace.zip
+
+Every test file's own name ends in `.py`, so a bare `-k "... and py"` selects
+both engines' parametrizations, not just Python's -- match the full
+parametrize id (`chromium-py`, not `py`) to get one. `--loader-delay` only
+holds back the *slow-load* test (`sabotage("off", ...)` is the only mode whose
+route handler installs the delay); it is a no-op on the failure-mode tests, so
+don't reach for it there. The status text only appears 3s after the loader
+mounts (`STATUS_DELAY_MS` in `src/Components/LoadingStatus.tsx`), so turn the
+delay up to give yourself time to read the stages. `--tracing on` overrides
+`pytest.ini`'s `--tracing retain-on-failure` and writes a trace even for a
+test that passes. Failures already keep one either way, and build.yml uploads
+`test-results/`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,9 +19,11 @@ from playwright.sync_api import expect
 
 from export_app import export_app
 from shinylive_app import (
+    ANALYTICS_URL,
     APP_FRAME,
     SHINYLIVE_DIR,
     STATIC_PORT,
+    is_benign_console_error,
     suspect_terminal_lines,
     terminal_text,
 )
@@ -31,14 +33,7 @@ from shinylive_app import (
 expect.set_options(timeout=30_000)
 
 
-# Analytics, which no test here is about. `make all` templates a Google Tag
-# Manager loader into the site's pages when GOOGLE_TAG_MANAGER_ID is set
-# (scripts/build.ts), which .github/workflows/build.yml does and test-apps.yml
-# does not -- so the site tests are the only ones that ever meet it, and they
-# meet it only on CI, next to the deploy they gate.
-_ANALYTICS_URL = re.compile(
-    r"https?://([^/]+\.)?(googletagmanager|google-analytics)\.com/"
-)
+# See `ANALYTICS_URL` and `is_benign_console_error` in shinylive_app.py.
 
 
 @pytest.fixture(autouse=True)
@@ -51,7 +46,7 @@ def block_analytics(page: Page) -> None:
     completes reaches the console as an error, the same way a missing favicon
     does.
     """
-    page.route(_ANALYTICS_URL, lambda route: route.abort())
+    page.route(ANALYTICS_URL, lambda route: route.abort())
 
 
 @pytest.fixture(autouse=True)
@@ -71,10 +66,7 @@ def fail_on_page_errors(request: pytest.FixtureRequest, page: Page) -> Iterator[
     def on_console(message: ConsoleMessage) -> None:
         if message.type != "error":
             return
-        # A missing favicon is not an app problem, and neither is the tag
-        # manager `block_analytics` just aborted.
-        url = message.location["url"]
-        if url.endswith("favicon.ico") or _ANALYTICS_URL.search(url):
+        if is_benign_console_error(message):
             return
         console_errors.append(message.text)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,22 +2,20 @@
 
 from __future__ import annotations
 
-import re
 import socket
 import subprocess
 import sys
 import threading
 import time
+from collections.abc import Callable, Iterator, Mapping
 from functools import partial
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Any, Callable, Iterator, Mapping
+from typing import Any
 
 import pytest
-from playwright.sync_api import ConsoleMessage, Page
-from playwright.sync_api import expect
-
 from export_app import export_app
+from playwright.sync_api import ConsoleMessage, Page, expect
 from shinylive_app import (
     ANALYTICS_URL,
     APP_FRAME,
@@ -88,9 +86,7 @@ def fail_on_page_errors(request: pytest.FixtureRequest, page: Page) -> Iterator[
         page.frame_locator(APP_FRAME).locator(".shiny-output-error"),
         "app rendered an output error",
     ).to_have_count(0)
-    assert console_errors == [], "browser console errors:\n" + "\n".join(
-        console_errors
-    )
+    assert console_errors == [], "browser console errors:\n" + "\n".join(console_errors)
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,6 +108,22 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         metavar="N/TOTAL",
         help="Run one part of the suite, as in `1/3`.",
     )
+    parser.addoption(
+        "--loader-delay",
+        type=int,
+        default=4000,
+        help=(
+            "Milliseconds to hold the engine's core wasm before answering. "
+            "LoadingStatus only shows text after 3s (STATUS_DELAY_MS), so the "
+            "default leaves about a second of visible status. Turn it up to "
+            "watch the stages by hand."
+        ),
+    )
+
+
+@pytest.fixture
+def loader_delay(request: pytest.FixtureRequest) -> int:
+    return int(request.config.getoption("--loader-delay"))
 
 
 def pytest_configure(config: pytest.Config) -> None:

--- a/tests/loader_apps.py
+++ b/tests/loader_apps.py
@@ -22,6 +22,7 @@ MODES = (
     "off",
     "app-syntax",
     "requirements",
+    "r-runtime",
     "engine-load",
     "engine-unreachable",
     "engine-setup",
@@ -91,6 +92,22 @@ def _files(engine: str, mode: str) -> list[dict[str, str]]:
                 "content": WORKING_APP["r"].replace(
                     "library(shiny)",
                     f"library(shiny)\nlibrary({MISSING_PKG.replace('-', '.')})",
+                ),
+            }
+        ]
+    if mode == "r-runtime":
+        # A runtime error at the app's top level, raised with a call attached so
+        # conditionCall() has something to report. parse() succeeds here, so
+        # this exercises the handler rather than the parse guard.
+        return [
+            {
+                "name": MAIN_FILE["r"],
+                "content": (
+                    "library(shiny)\n\n"
+                    "stop('deliberate failure')\n\n"
+                    'ui <- fluidPage(h1("unreachable"))\n'
+                    "server <- function(input, output, session) { }\n"
+                    "shinyApp(ui, server)\n"
                 ),
             }
         ]

--- a/tests/loader_apps.py
+++ b/tests/loader_apps.py
@@ -70,6 +70,8 @@ SYNTAX_ERROR_APP = {
 
 
 def _files(engine: str, mode: str) -> list[dict[str, str]]:
+    if mode not in MODES:
+        raise ValueError(f"unknown mode {mode!r}; must be one of {MODES}")
     main = MAIN_FILE[engine]
     if mode == "app-syntax":
         return [{"name": main, "content": SYNTAX_ERROR_APP[engine]}]
@@ -105,6 +107,8 @@ def app_url(engine: str, mode: str, view: str = "app") -> str:
 
 def sabotage(page: Page, engine: str, mode: str, delay_ms: int) -> None:
     """Install whatever route handlers `mode` needs. A no-op for app-level modes."""
+    if mode not in MODES:
+        raise ValueError(f"unknown mode {mode!r}; must be one of {MODES}")
     if mode == "engine-load":
         page.route(CORE_ASSET[engine], lambda r: r.fulfill(status=404, body="nope"))
         return

--- a/tests/loader_apps.py
+++ b/tests/loader_apps.py
@@ -78,13 +78,15 @@ def _files(engine: str, mode: str) -> list[dict[str, str]]:
     if mode == "app-syntax":
         files = [{"name": main, "content": SYNTAX_ERROR_APP[engine]}]
         if engine == "r":
-            # A second, valid .R file, so .start_app's parse guard iterates over
-            # more than one and its re-raise has a file to lose. The guard drops
-            # the condition's call (which would name only its own loop variable)
-            # and keeps the message, and the path lives in that message -- so the
+            # A second, valid .R file that sorts before app.R, so .start_app's
+            # parse guard -- which iterates list.files() in sorted order and
+            # stop()s on the first failure -- actually parses more than one file
+            # before it gets to the one that fails. The guard drops the
+            # condition's call (which would name only its own loop variable) and
+            # keeps the message, and the path lives in that message -- so the
             # dialog naming app.R is what shows the path survived.
             files.append(
-                {"name": "helpers.R", "content": "double <- function(x) x * 2\n"}
+                {"name": "aaa_helpers.R", "content": "double <- function(x) x * 2\n"}
             )
         return files
     if mode == "requirements":

--- a/tests/loader_apps.py
+++ b/tests/loader_apps.py
@@ -13,7 +13,6 @@ import time
 
 import lzstring
 from playwright.sync_api import Page, Route
-
 from shinylive_app import BASE_URL
 
 _LZ = lzstring.LZString()

--- a/tests/loader_apps.py
+++ b/tests/loader_apps.py
@@ -23,6 +23,7 @@ MODES = (
     "app-syntax",
     "requirements",
     "r-runtime",
+    "r-runtime-call",
     "engine-load",
     "engine-unreachable",
     "engine-setup",
@@ -96,15 +97,44 @@ def _files(engine: str, mode: str) -> list[dict[str, str]]:
             }
         ]
     if mode == "r-runtime":
-        # A runtime error at the app's top level, raised with a call attached so
-        # conditionCall() has something to report. parse() succeeds here, so
-        # this exercises the handler rather than the parse guard.
+        # A fatal error at the app's top level. parse() succeeds here, so this
+        # exercises .start_app's condition handler rather than its parse guard.
+        # The only call such a condition carries is shiny's ..stacktraceon..
+        # wrapper, which .start_app drops, so this is the mode that shows the
+        # dialog falling back to the bare message.
         return [
             {
                 "name": MAIN_FILE["r"],
                 "content": (
                     "library(shiny)\n\n"
                     "stop('deliberate failure')\n\n"
+                    'ui <- fluidPage(h1("unreachable"))\n'
+                    "server <- function(input, output, session) { }\n"
+                    "shinyApp(ui, server)\n"
+                ),
+            }
+        ]
+    if mode == "r-runtime-call":
+        # The same failure, one frame down: raised inside a function the app
+        # author wrote and called, so conditionCall() names `load_data(...)`
+        # rather than shiny's wrapper. This is the case reporting the call is
+        # for.
+        #
+        # The call is deliberately wider than deparse()'s 60-character cutoff so
+        # that it deparses to more than one line, which is what puts
+        # `truncated_marker` past the first line -- the only argument the dialog
+        # must not show.
+        return [
+            {
+                "name": MAIN_FILE["r"],
+                "content": (
+                    "library(shiny)\n\n"
+                    "load_data <- function(path, columns, truncated_marker) {\n"
+                    "  stop('deliberate failure')\n"
+                    "}\n\n"
+                    'load_data(path = "a/path/long/enough/to/split/the/deparse.csv",\n'
+                    '          columns = c("first", "second"),\n'
+                    "          truncated_marker = TRUE)\n\n"
                     'ui <- fluidPage(h1("unreachable"))\n'
                     "server <- function(input, output, session) { }\n"
                     "shinyApp(ui, server)\n"

--- a/tests/loader_apps.py
+++ b/tests/loader_apps.py
@@ -1,0 +1,147 @@
+"""App sources, URL hashes and sabotage for the loader-status tests.
+
+The app source travels in the URL hash, the same mechanism test_site_url_loading
+uses: an LZ-compressed JSON array of {name, content}. That covers every app-level
+failure without intercepting a request. Only the engine-level modes need
+page.route().
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import lzstring
+from playwright.sync_api import Page, Route
+
+from shinylive_app import BASE_URL
+
+_LZ = lzstring.LZString()
+
+MODES = (
+    "off",
+    "app-syntax",
+    "requirements",
+    "engine-load",
+    "engine-unreachable",
+    "engine-setup",
+)
+
+MAIN_FILE = {"py": "app.py", "r": "app.R"}
+
+# The one request every engine makes unconditionally during startup, and the
+# thing engine-load / engine-unreachable sabotage.
+CORE_ASSET = {
+    "py": "**/pyodide/pyodide.asm.wasm",
+    "r": "**/webr/R.wasm",
+}
+
+# engine-setup needs a failure *after* loadPyodide() resolves, which no missing
+# asset can produce. Rewriting the first line of Python that setupPythonEnv()
+# runs lands in that window -- the one where the worker holds a live pyodide but
+# no pyUtils.
+WORKER_BUNDLE = "**/pyodide-worker.js"
+SETUP_ANCHOR = "import pyodide.console"
+
+MISSING_PKG = "definitely-not-a-real-package"
+
+WORKING_APP = {
+    "py": (
+        "from shiny import App, render, ui\n\n"
+        'app_ui = ui.page_fluid(ui.h1("Loader test"))\n\n\n'
+        "def server(input, output, session):\n    pass\n\n\n"
+        "app = App(app_ui, server)\n"
+    ),
+    "r": (
+        "library(shiny)\n\n"
+        'ui <- fluidPage(h1("Loader test"))\n\n'
+        "server <- function(input, output, session) { }\n\n"
+        "shinyApp(ui, server)\n"
+    ),
+}
+
+# `server` on its own line is a bare symbol where a call is expected: a parse
+# error R reports with a line number and caret, and Python reports as a
+# SyntaxError.
+SYNTAX_ERROR_APP = {
+    "py": "from shiny import App, ui\n\napp_ui = ui.page_fluid(\n",
+    "r": "library(shiny)\n\nui <- fluidPage(\nserver\n",
+}
+
+
+def _files(engine: str, mode: str) -> list[dict[str, str]]:
+    main = MAIN_FILE[engine]
+    if mode == "app-syntax":
+        return [{"name": main, "content": SYNTAX_ERROR_APP[engine]}]
+    if mode == "requirements":
+        if engine == "py":
+            return [
+                {"name": main, "content": WORKING_APP["py"]},
+                {
+                    "name": "requirements.txt",
+                    "content": f"# Does not exist, so micropip.install() fails.\n{MISSING_PKG}\n",
+                },
+            ]
+        # R has no requirements file: .start_app scans for library() calls.
+        return [
+            {
+                "name": main,
+                "content": WORKING_APP["r"].replace(
+                    "library(shiny)",
+                    f"library(shiny)\nlibrary({MISSING_PKG.replace('-', '.')})",
+                ),
+            }
+        ]
+    # "off" and the engine-* modes all want a working app: when the engine never
+    # starts, the app code is never reached.
+    return [{"name": main, "content": WORKING_APP[engine]}]
+
+
+def app_url(engine: str, mode: str, view: str = "app") -> str:
+    files = _files(engine, mode)
+    code = _LZ.compressToEncodedURIComponent(json.dumps(files))
+    return f"{BASE_URL}/{engine}/{view}/#code={code}"
+
+
+def sabotage(page: Page, engine: str, mode: str, delay_ms: int) -> None:
+    """Install whatever route handlers `mode` needs. A no-op for app-level modes."""
+    if mode == "engine-load":
+        page.route(CORE_ASSET[engine], lambda r: r.fulfill(status=404, body="nope"))
+        return
+    if mode == "engine-unreachable":
+        # fetch() rejects rather than returning a status: a separate branch of
+        # the same check.
+        page.route(CORE_ASSET[engine], lambda r: r.abort())
+        return
+    if mode == "engine-setup":
+        page.route(WORKER_BUNDLE, _break_setup)
+        return
+    if mode == "off":
+        page.route(CORE_ASSET[engine], lambda r: _delay(r, delay_ms))
+
+
+def _delay(route: Route, delay_ms: int) -> None:
+    """Answer late, so the loader has stages worth reporting.
+
+    A fixed delay rather than CDP bandwidth throttling: throttling ties the
+    timing to how loaded the runner is, and these assertions are about the
+    order of stages, not their duration.
+
+    time.sleep() rather than page.wait_for_timeout(): the sync API dispatches
+    route handlers on the same greenlet as the page call that triggered them, so
+    issuing another page call from in here deadlocks.
+    """
+    time.sleep(delay_ms / 1000)
+    route.continue_()
+
+
+def _break_setup(route: Route) -> None:
+    body = route.fetch().text()
+    assert SETUP_ANCHOR in body, (
+        f"{SETUP_ANCHOR!r} is gone from the worker bundle; engine-setup needs "
+        "another way to fail after loadPyodide() resolves"
+    )
+    route.fulfill(
+        body=body.replace(SETUP_ANCHOR, "import shinylive_no_such_module"),
+        content_type="text/javascript",
+    )

--- a/tests/loader_apps.py
+++ b/tests/loader_apps.py
@@ -76,7 +76,17 @@ def _files(engine: str, mode: str) -> list[dict[str, str]]:
         raise ValueError(f"unknown mode {mode!r}; must be one of {MODES}")
     main = MAIN_FILE[engine]
     if mode == "app-syntax":
-        return [{"name": main, "content": SYNTAX_ERROR_APP[engine]}]
+        files = [{"name": main, "content": SYNTAX_ERROR_APP[engine]}]
+        if engine == "r":
+            # A second, valid .R file, so .start_app's parse guard iterates over
+            # more than one and its re-raise has a file to lose. The guard drops
+            # the condition's call (which would name only its own loop variable)
+            # and keeps the message, and the path lives in that message -- so the
+            # dialog naming app.R is what shows the path survived.
+            files.append(
+                {"name": "helpers.R", "content": "double <- function(x) x * 2\n"}
+            )
+        return files
     if mode == "requirements":
         if engine == "py":
             return [

--- a/tests/shinylive_app.py
+++ b/tests/shinylive_app.py
@@ -15,9 +15,32 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any, cast
 
-from playwright.sync_api import FrameLocator, Locator, Page
+from playwright.sync_api import ConsoleMessage, FrameLocator, Locator, Page
 from playwright.sync_api import expect as playwright_expect
 from shiny.playwright.controller import OutputPlot as OutputPlotBase
+
+# Analytics, which no test here is about. `make all` templates a Google Tag
+# Manager loader into the site's pages when GOOGLE_TAG_MANAGER_ID is set
+# (scripts/build.ts), which .github/workflows/build.yml does and test-apps.yml
+# does not -- so the site tests are the only ones that meet it, and only on CI.
+ANALYTICS_URL = re.compile(
+    r"https?://([^/]+\.)?(googletagmanager|google-analytics)\.com/"
+)
+
+
+def is_benign_console_error(message: ConsoleMessage) -> bool:
+    """Whether a console error is noise rather than an app problem.
+
+    A missing favicon is not an app problem, and neither is the tag manager that
+    `block_analytics` just aborted -- an aborted request reaches the console as
+    `net::ERR_FAILED`. Shared with `fail_on_page_errors` in conftest.py so that a
+    test opting out of that fixture and collecting console errors itself does not
+    have to rediscover which ones to forgive. Getting this wrong is invisible
+    locally, because the tag manager is only templated in on CI.
+    """
+    url = message.location["url"]
+    return url.endswith("favicon.ico") or bool(ANALYTICS_URL.search(url))
+
 
 # Where `make _shinylive` puts the built sites.
 SHINYLIVE_DIR = Path(__file__).resolve().parent.parent / "_shinylive"

--- a/tests/test_loader_status.py
+++ b/tests/test_loader_status.py
@@ -17,6 +17,31 @@ pytestmark = [pytest.mark.site, pytest.mark.loader]
 
 ENGINE_LABEL = {"py": "Python", "r": "R"}
 
+# Installed with `page.add_init_script()`, before either of `sabotage("off",
+# ...)`'s two delays has a chance to fire (see the docstring on
+# test_slow_load_announces_its_stages for why that matters). Records every
+# change to the loader's own DOM with a timestamp, in the page rather than in
+# this process, so the recording is immune to how blocked this process gets.
+_STAGE_RECORDER_SCRIPT = """
+window.__stageLog = [];
+const t0 = performance.now();
+const record = () => {
+  const wrapper = document.querySelector(".loading-status");
+  const stage = document.querySelector(".loading-stage");
+  window.__stageLog.push({
+    t: performance.now() - t0,
+    wrapper: !!wrapper,
+    text: stage ? stage.textContent : null,
+  });
+};
+new MutationObserver(record).observe(document, {
+  subtree: true,
+  childList: true,
+  characterData: true,
+});
+record();
+"""
+
 
 @pytest.mark.allow_page_errors
 @pytest.mark.parametrize("engine", ["py", "r"])
@@ -174,6 +199,71 @@ def test_r_unresolvable_library_still_runs(page: Page, loader_delay: int) -> Non
     missing_pkg_r_name = MISSING_PKG.replace("-", ".")
     assert "webr::install" in combined, combined
     assert f"{missing_pkg_r_name} not found in webR binary repo" in combined, combined
+
+
+@pytest.mark.parametrize("engine", ["py", "r"])
+def test_slow_load_announces_its_stages(
+    page: Page, engine: str, loader_delay: int
+) -> None:
+    """The feature's headline behaviour: a slow first load explains itself.
+
+    Deliberately carries no `@pytest.mark.allow_page_errors`: this is a
+    successful load, so `fail_on_page_errors` should see nothing at all, and
+    that marker would mask real console noise rather than let it fail the test.
+
+    Reads back a recording rather than polling live for each stage in turn.
+    `sabotage("off", ...)` answers the engine's core-wasm requests with
+    `time.sleep()`, which -- per that function's own docstring -- blocks this
+    whole process's connection to the browser, not just the one request it is
+    answering. The engine makes *two* such requests before it is up
+    (`engine-load-guard`'s reachability check, then the real load), so any of
+    this test's own commands, including `page.goto()` itself, can each land in
+    the middle of one of those sleeps and block for a full `loader_delay`
+    with no way to poll in between. A first version of this test used
+    sequential `expect(...).to_have_text(...)` calls to assert the order, and
+    it was flaky in exactly that way: on a fast local engine, enough of that
+    blocked time could go by that the app finished booting before the first
+    check ever got a chance to observe the DOM, and text that has already
+    come and gone does not come back for a later, more patient `expect()` to
+    find. A `MutationObserver`, installed before either delay has fired,
+    sidesteps this: it runs in the browser and timestamps every change to the
+    loader's own DOM, so the recording it produces is immune to how blocked
+    this process gets. This test lets the load run to completion and then
+    reads that recording back once.
+    """
+    page.add_init_script(_STAGE_RECORDER_SCRIPT)
+    sabotage(page, engine, "off", loader_delay)
+    page.goto(app_url(engine, "off"))
+
+    from shinylive_app import wait_for_app_rendered
+
+    wait_for_app_rendered(page)
+    expect(page.locator(".loading-status")).to_have_count(0)
+
+    label = ENGINE_LABEL[engine]
+    log = page.evaluate("window.__stageLog")
+
+    # STATUS_DELAY_MS (LoadingStatus.tsx) withholds the stage text for the
+    # first 3s. Anchored on the recording's own first "wrapper is up" entry
+    # rather than assumed to be t=0, so this cannot pass vacuously just
+    # because the observer happened to attach before the loader even mounted.
+    mounted = next(entry for entry in log if entry["wrapper"])
+    first_text = next(entry for entry in log if entry["text"])
+    assert first_text["t"] - mounted["t"] >= 2_500, (
+        "stage text appeared less than ~3s after the loader mounted",
+        log,
+    )
+
+    # The order stages appeared in, deduplicated -- the recording is a log of
+    # every DOM mutation, so the same stage text shows up on more than one
+    # entry in a row.
+    seen = [entry["text"] for entry in log if entry["text"] is not None]
+    stages = [text for i, text in enumerate(seen) if i == 0 or text != seen[i - 1]]
+    assert stages == [
+        f"Downloading {label}…",
+        f"Starting {label}…",
+        "Loading packages and starting app…",
+    ], stages
 
 
 def test_an_unknown_mode_is_rejected_before_it_reaches_the_page() -> None:

--- a/tests/test_loader_status.py
+++ b/tests/test_loader_status.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import Iterator, cast
 
 import pytest
-from playwright.sync_api import Page, expect
+from playwright.sync_api import ConsoleMessage, Page, expect
 
 from loader_apps import MISSING_PKG, _files, app_url, sabotage
 from shinylive_app import BASE_URL
@@ -177,12 +177,21 @@ def test_r_unresolvable_library_still_runs(page: Page, loader_delay: int) -> Non
     else -- an unrelated error, or this one going silent -- still fails the
     test.
     """
-    from shinylive_app import wait_for_app_rendered
+    from shinylive_app import is_benign_console_error, wait_for_app_rendered
 
+    # Collecting console errors by hand means also forgiving what
+    # fail_on_page_errors forgives -- the aborted tag-manager requests, which
+    # arrive as "Failed to load resource: net::ERR_FAILED". They only appear on
+    # CI, where make all templates the tag manager in, so a local run cannot
+    # catch the omission. Hence the shared predicate rather than a second copy of
+    # the rule.
     errors: list[str] = []
-    page.on(
-        "console", lambda m: errors.append(m.text) if m.type == "error" else None
-    )
+
+    def collect(message: ConsoleMessage) -> None:
+        if message.type == "error" and not is_benign_console_error(message):
+            errors.append(message.text)
+
+    page.on("console", collect)
 
     sabotage(page, "r", "requirements", loader_delay)
     page.goto(app_url("r", "requirements"))

--- a/tests/test_loader_status.py
+++ b/tests/test_loader_status.py
@@ -75,6 +75,54 @@ def test_engine_setup_failure_replies_instead_of_hanging(
     )
 
 
+@pytest.mark.allow_page_errors
+@pytest.mark.parametrize("engine", ["py", "r"])
+def test_app_syntax_error_shows_no_recovery_hint(
+    page: Page, engine: str, loader_delay: int
+) -> None:
+    """Absorbs viewer-error.test.tsx's second and third cases."""
+    sabotage(page, engine, "app-syntax", loader_delay)
+    page.goto(app_url(engine, "app-syntax"))
+    expect(page.locator(".error-message")).to_have_text("Error starting app!")
+    expect(page.locator(".error-recovery")).to_have_count(0)
+    expect(page.locator(".error-log pre")).not_to_be_empty()
+
+
+@pytest.mark.allow_page_errors
+def test_r_syntax_error_reports_the_line(page: Page, loader_delay: int) -> None:
+    """shiny's sourceUTF8 catches the parse error and re-raises a bare
+    "Error sourcing <file>". .start_app parses the app's files first so the real
+    message survives; this asserts that it still does.
+    """
+    sabotage(page, "r", "app-syntax", loader_delay)
+    page.goto(app_url("r", "app-syntax"))
+    log = page.locator(".error-log pre")
+    expect(log).to_contain_text("app.R:")
+    expect(log).to_contain_text("^")
+
+
+@pytest.mark.allow_page_errors
+def test_python_unresolvable_requirement_fails_the_app(
+    page: Page, loader_delay: int
+) -> None:
+    sabotage(page, "py", "requirements", loader_delay)
+    page.goto(app_url("py", "requirements"))
+    expect(page.locator(".error-message")).to_have_text("Error starting app!")
+
+
+def test_r_unresolvable_library_still_runs(page: Page, loader_delay: int) -> None:
+    """Deliberately not fatal (useWebR.tsx:371-376): renv::dependencies() also
+    reports packages that are named but never used, and those apps run today.
+    No allow_page_errors -- this one is expected to be clean.
+    """
+    from shinylive_app import wait_for_app_rendered
+
+    sabotage(page, "r", "requirements", loader_delay)
+    page.goto(app_url("r", "requirements"))
+    wait_for_app_rendered(page)
+    expect(page.locator(".loading-wrapper-error")).to_have_count(0)
+
+
 def test_an_unknown_mode_is_rejected_before_it_reaches_the_page() -> None:
     """A typo'd mode string should fail loudly at the call, not silently at
     the assertion. `_files()` and `sabotage()`'s guards run before either

--- a/tests/test_loader_status.py
+++ b/tests/test_loader_status.py
@@ -82,8 +82,14 @@ def test_r_syntax_error_reports_the_line(page: Page, loader_delay: int) -> None:
     sabotage(page, "r", "app-syntax", loader_delay)
     page.goto(app_url("r", "app-syntax"))
     log = page.locator(".error-log pre")
+    # The R fixture ships a second, valid .R file, so this also pins which of the
+    # files the guard iterated is named as the one that failed.
     expect(log).to_contain_text("app.R:")
     expect(log).to_contain_text("^")
+    # The guard re-raises without the condition's call, which would otherwise be
+    # its own parse(file = f) -- a prefix naming our loop variable, in front of
+    # the message that is the entire point of parsing here.
+    expect(log).not_to_contain_text("Error in parse")
 
 
 @pytest.mark.allow_page_errors

--- a/tests/test_loader_status.py
+++ b/tests/test_loader_status.py
@@ -6,14 +6,13 @@ for how to watch one in a browser.
 
 from __future__ import annotations
 
-import uuid
 from typing import Iterator, cast
 
 import pytest
 from playwright.sync_api import Page, expect
 
 from loader_apps import MISSING_PKG, _files, app_url, sabotage
-from shinylive_app import BASE_URL, SHINYLIVE_DIR
+from shinylive_app import BASE_URL
 
 pytestmark = [pytest.mark.site, pytest.mark.loader]
 
@@ -289,8 +288,8 @@ def _codeblock_body(files: list[dict[str, str]]) -> str:
 
 
 @pytest.fixture
-def embed_page(engine: str, mode: str) -> Iterator[str]:
-    """A minimal page with one embedded block, served from the site root.
+def embed_page(page: Page, engine: str, mode: str) -> Iterator[str]:
+    """A minimal page with one embedded block, served from the site origin.
 
     Embedded blocks take their engine from the block's own class
     (run-python-blocks.ts selects on ".shinylive-python, .shinylive-r"), so one
@@ -299,9 +298,19 @@ def embed_page(engine: str, mode: str) -> Iterator[str]:
     `_shinylive/r/shinylive/` are byte-for-byte identical, so the only thing
     that determines which engine actually runs is the block's class below.
 
-    The page is still written next to whichever engine's own `shinylive-sw.js`
-    matches `engine`: load-shinylive-sw.js derives the service worker's path
-    from the page's own directory, the same way the built editor/app pages do.
+    Fulfilled with `page.route()` for a URL under the real static server
+    rather than written to `_shinylive/<engine>/` on disk: that directory is a
+    live build artifact (`make _shinylive`'s `cp -Lr`, a non-cleaning overlay
+    copy), and a stray file surviving a hard crash -- a CI timeout, SIGKILL,
+    anything that skips a `finally` -- would ride into every later build and
+    ultimately the deploy. `sabotage()` already fulfils/rewrites responses
+    this way for the engine-level modes; this is the same technique for the
+    page itself, with zero filesystem footprint. The origin and directory
+    depth (`{BASE_URL}/<engine>/...`) are unchanged from a real page there, so
+    the block's relative `shinylive/...` asset paths, and the service worker
+    scope load-shinylive-sw.js derives from the page's own directory, still
+    resolve against the real files `static_server` serves -- only this one URL
+    is intercepted; every other request passes through untouched.
 
     Modeled on scripts/loader-demo.ts's embedPage()/buildDemoSite() -- the last
     known-working generator of this markup, since replaced by this test.
@@ -324,14 +333,11 @@ def embed_page(engine: str, mode: str) -> Iterator[str]:
   </body>
 </html>
 """
-    # A unique name per test so parallel runs (xdist, or two parametrized cases
-    # touching the same engine) never collide on the same file.
-    page_path = SHINYLIVE_DIR / engine / f"_embed_test_{uuid.uuid4().hex}.html"
-    page_path.write_text(html)
-    try:
-        yield f"{BASE_URL}/{engine}/{page_path.name}"
-    finally:
-        page_path.unlink(missing_ok=True)
+    url = f"{BASE_URL}/{engine}/_embed_test.html"
+    page.route(
+        url, lambda route: route.fulfill(content_type="text/html", body=html)
+    )
+    yield url
 
 
 @pytest.mark.allow_page_errors
@@ -344,23 +350,36 @@ def test_embedded_block_shows_the_error(
     across layouts, so what is being checked here is the error screen's
     presentation inside a small block rather than the detection.
 
-    Asserts the exact headline rather than just that one showed up: for the
-    "r" case this is what would catch the embed accidentally booting Pyodide
-    instead of webR (or vice versa) -- a wrong-language headline is the one
-    symptom a mixed-up engine could not hide.
+    "engine-load" 404s `**/webr/R.wasm` or `**/pyodide/pyodide.asm.wasm`
+    specifically (see `sabotage()`), so its exact "Error loading R!"/"Error
+    loading Python!" headline can only appear if the matching engine actually
+    requested that asset -- that assertion alone would catch a `.shinylive-r`
+    block that silently booted Pyodide instead of webR (or vice versa).
+
+    "app-syntax" sabotages nothing at the network level, and its headline
+    ("Error starting app!") and recovery-hint absence are engine-agnostic, so
+    neither would notice a mixed-up engine: the R syntax-error source
+    (SYNTAX_ERROR_APP["r"]) also fails to compile as Python, so a
+    `.shinylive-r` block that silently ran Pyodide on it would still produce
+    every one of those symptoms. What does differ is the log's own content --
+    `.start_app`'s parse guard names `app.R` with a line and caret for R, while
+    Pyodide's SyntaxError names `app.py` -- so that is the assertion this mode
+    needs to be discriminating rather than merely present.
     """
     sabotage(page, engine, mode, loader_delay)
     page.goto(embed_page)
+    log = page.locator(".error-log pre")
     if mode == "app-syntax":
         expect(page.locator(".error-message")).to_have_text("Error starting app!")
         expect(page.locator(".error-recovery")).to_have_count(0)
+        expect(log).to_contain_text("app.R" if engine == "r" else "app.py")
     else:
         expect(page.locator(".error-message")).to_have_text(
             f"Error loading {ENGINE_LABEL[engine]}!"
         )
         expect(page.locator(".error-recovery")).to_be_visible()
-        expect(page.locator(".error-log pre")).to_contain_text("404")
-    expect(page.locator(".error-log pre")).not_to_be_empty()
+        expect(log).to_contain_text("404")
+    expect(log).not_to_be_empty()
 
 
 def test_an_unknown_mode_is_rejected_before_it_reaches_the_page() -> None:

--- a/tests/test_loader_status.py
+++ b/tests/test_loader_status.py
@@ -6,6 +6,8 @@ for how to watch one in a browser.
 
 from __future__ import annotations
 
+from typing import cast
+
 import pytest
 from playwright.sync_api import Page, expect
 
@@ -20,3 +22,16 @@ def test_missing_engine_asset_reports_the_status(page: Page, loader_delay: int) 
     page.goto(app_url("py", "engine-load"))
     expect(page.locator(".error-message")).to_have_text("Error loading Python!")
     expect(page.locator(".error-log pre")).to_contain_text("404")
+
+
+def test_an_unknown_mode_is_rejected_before_it_reaches_the_page() -> None:
+    """A typo'd mode string should fail loudly at the call, not silently at
+    the assertion. `_files()` and `sabotage()`'s guards run before either
+    function touches a page, so this needs neither a browser nor
+    `allow_page_errors`: the page passed to `sabotage()` here is a stand-in
+    that would blow up if the guard did not raise first.
+    """
+    with pytest.raises(ValueError):
+        app_url("py", "bogus-mode")
+    with pytest.raises(ValueError):
+        sabotage(cast(Page, None), "py", "bogus-mode", 0)

--- a/tests/test_loader_status.py
+++ b/tests/test_loader_status.py
@@ -6,12 +6,14 @@ for how to watch one in a browser.
 
 from __future__ import annotations
 
-from typing import cast
+import uuid
+from typing import Iterator, cast
 
 import pytest
 from playwright.sync_api import Page, expect
 
-from loader_apps import MISSING_PKG, app_url, sabotage
+from loader_apps import MISSING_PKG, _files, app_url, sabotage
+from shinylive_app import BASE_URL, SHINYLIVE_DIR
 
 pytestmark = [pytest.mark.site, pytest.mark.loader]
 
@@ -265,6 +267,100 @@ def test_slow_load_announces_its_stages(
         f"Starting {label}…",
         "Loading packages and starting app…",
     ], stages
+
+
+_EMBED_BLOCK_CLASS = {"py": "shinylive-python", "r": "shinylive-r"}
+
+# Arbitrary but fixed, so the block never scrolls; nothing here depends on the
+# exact value.
+_EMBED_VIEWER_HEIGHT = 320
+
+
+def _codeblock_body(files: list[dict[str, str]]) -> str:
+    """Render a file set as a shinylive code-block body.
+
+    Mirrors codeBlockBody() in scripts/loader-demo.ts: a single file needs no
+    header, and more than one uses the '## file:' syntax parse-codeblock.ts
+    understands.
+    """
+    if len(files) == 1:
+        return files[0]["content"]
+    return "\n".join(f"## file: {f['name']}\n{f['content']}" for f in files).rstrip()
+
+
+@pytest.fixture
+def embed_page(engine: str, mode: str) -> Iterator[str]:
+    """A minimal page with one embedded block, served from the site root.
+
+    Embedded blocks take their engine from the block's own class
+    (run-python-blocks.ts selects on ".shinylive-python, .shinylive-r"), so one
+    JS bundle serves both -- unlike the full-page layout, where the engine is
+    substituted into the HTML at build time. `_shinylive/py/shinylive/` and
+    `_shinylive/r/shinylive/` are byte-for-byte identical, so the only thing
+    that determines which engine actually runs is the block's class below.
+
+    The page is still written next to whichever engine's own `shinylive-sw.js`
+    matches `engine`: load-shinylive-sw.js derives the service worker's path
+    from the page's own directory, the same way the built editor/app pages do.
+
+    Modeled on scripts/loader-demo.ts's embedPage()/buildDemoSite() -- the last
+    known-working generator of this markup, since replaced by this test.
+    """
+    body = _codeblock_body(_files(engine, mode))
+    html = f"""<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <script src="shinylive/load-shinylive-sw.js" type="module"></script>
+    <link href="shinylive/shinylive.css" rel="stylesheet" />
+    <script src="shinylive/run-python-blocks.js" type="module"></script>
+  </head>
+  <body>
+    <pre class="{_EMBED_BLOCK_CLASS[engine]}">
+#| standalone: true
+#| viewerHeight: {_EMBED_VIEWER_HEIGHT}
+
+{body}</pre>
+  </body>
+</html>
+"""
+    # A unique name per test so parallel runs (xdist, or two parametrized cases
+    # touching the same engine) never collide on the same file.
+    page_path = SHINYLIVE_DIR / engine / f"_embed_test_{uuid.uuid4().hex}.html"
+    page_path.write_text(html)
+    try:
+        yield f"{BASE_URL}/{engine}/{page_path.name}"
+    finally:
+        page_path.unlink(missing_ok=True)
+
+
+@pytest.mark.allow_page_errors
+@pytest.mark.parametrize("engine", ["py", "r"])
+@pytest.mark.parametrize("mode", ["app-syntax", "engine-load"])
+def test_embedded_block_shows_the_error(
+    page: Page, engine: str, mode: str, loader_delay: int, embed_page: str
+) -> None:
+    """Two representative modes, not all six: the failure plumbing is identical
+    across layouts, so what is being checked here is the error screen's
+    presentation inside a small block rather than the detection.
+
+    Asserts the exact headline rather than just that one showed up: for the
+    "r" case this is what would catch the embed accidentally booting Pyodide
+    instead of webR (or vice versa) -- a wrong-language headline is the one
+    symptom a mixed-up engine could not hide.
+    """
+    sabotage(page, engine, mode, loader_delay)
+    page.goto(embed_page)
+    if mode == "app-syntax":
+        expect(page.locator(".error-message")).to_have_text("Error starting app!")
+        expect(page.locator(".error-recovery")).to_have_count(0)
+    else:
+        expect(page.locator(".error-message")).to_have_text(
+            f"Error loading {ENGINE_LABEL[engine]}!"
+        )
+        expect(page.locator(".error-recovery")).to_be_visible()
+        expect(page.locator(".error-log pre")).to_contain_text("404")
+    expect(page.locator(".error-log pre")).not_to_be_empty()
 
 
 def test_an_unknown_mode_is_rejected_before_it_reaches_the_page() -> None:

--- a/tests/test_loader_status.py
+++ b/tests/test_loader_status.py
@@ -243,15 +243,16 @@ def test_slow_load_announces_its_stages(
     label = ENGINE_LABEL[engine]
     log = page.evaluate("window.__stageLog")
 
-    # STATUS_DELAY_MS (LoadingStatus.tsx) withholds the stage text for the
-    # first 3s. Anchored on the recording's own first "wrapper is up" entry
-    # rather than assumed to be t=0, so this cannot pass vacuously just
-    # because the observer happened to attach before the loader even mounted.
+    # STATUS_DELAY_MS (LoadingStatus.tsx) withholds the stage text until 3s
+    # after the loader mounts. Asserted as an absence, not a duration: the
+    # recording's own first "wrapper is up" entry -- not assumed to be the
+    # log's first entry, in case the observer fired for some other reason
+    # first -- must show no stage text yet. `next()` raises on an empty log
+    # rather than letting this pass vacuously.
     mounted = next(entry for entry in log if entry["wrapper"])
-    first_text = next(entry for entry in log if entry["text"])
-    assert first_text["t"] - mounted["t"] >= 2_500, (
-        "stage text appeared less than ~3s after the loader mounted",
-        log,
+    assert mounted["text"] is None, (
+        "stage text was already showing when the loader mounted",
+        mounted,
     )
 
     # The order stages appeared in, deduplicated -- the recording is a log of

--- a/tests/test_loader_status.py
+++ b/tests/test_loader_status.py
@@ -6,12 +6,12 @@ for how to watch one in a browser.
 
 from __future__ import annotations
 
-from typing import Iterator, cast
+from collections.abc import Iterator
+from typing import cast
 
 import pytest
-from playwright.sync_api import ConsoleMessage, Page, expect
-
 from loader_apps import MISSING_PKG, _files, app_url, sabotage
+from playwright.sync_api import ConsoleMessage, Page, expect
 from shinylive_app import BASE_URL
 
 pytestmark = [pytest.mark.site, pytest.mark.loader]
@@ -224,23 +224,16 @@ def test_slow_load_announces_its_stages(
 
     Reads back a recording rather than polling live for each stage in turn.
     `sabotage("off", ...)` answers the engine's core-wasm requests with
-    `time.sleep()`, which -- per that function's own docstring -- blocks this
-    whole process's connection to the browser, not just the one request it is
-    answering. The engine makes *two* such requests before it is up
-    (`engine-load-guard`'s reachability check, then the real load), so any of
-    this test's own commands, including `page.goto()` itself, can each land in
-    the middle of one of those sleeps and block for a full `loader_delay`
-    with no way to poll in between. A first version of this test used
-    sequential `expect(...).to_have_text(...)` calls to assert the order, and
-    it was flaky in exactly that way: on a fast local engine, enough of that
-    blocked time could go by that the app finished booting before the first
-    check ever got a chance to observe the DOM, and text that has already
-    come and gone does not come back for a later, more patient `expect()` to
-    find. A `MutationObserver`, installed before either delay has fired,
-    sidesteps this: it runs in the browser and timestamps every change to the
-    loader's own DOM, so the recording it produces is immune to how blocked
-    this process gets. This test lets the load run to completion and then
-    reads that recording back once.
+    `time.sleep()`, which blocks this whole process's connection to the browser,
+    not just the one request it is answering. The engine makes *two* such requests
+    before it is up (`engine-load-guard`'s reachability check, then the real load),
+    so any of this test's own commands, including `page.goto()` itself, can each land
+    in the middle of one of those sleeps and block for a full `loader_delay`
+    with no way to poll in between. A `MutationObserver`, installed before either
+    delay has fired, sidesteps some observed flakiness: it runs in the browser and
+    timestamps every change to the loader's own DOM, so the recording it produces is
+    immune to how blocked this process gets. This test lets the load run to completion
+    and then reads that recording back once.
     """
     page.add_init_script(_STAGE_RECORDER_SCRIPT)
     sabotage(page, engine, "off", loader_delay)
@@ -344,9 +337,7 @@ def embed_page(page: Page, engine: str, mode: str) -> Iterator[str]:
 </html>
 """
     url = f"{BASE_URL}/{engine}/_embed_test.html"
-    page.route(
-        url, lambda route: route.fulfill(content_type="text/html", body=html)
-    )
+    page.route(url, lambda route: route.fulfill(content_type="text/html", body=html))
     yield url
 
 

--- a/tests/test_loader_status.py
+++ b/tests/test_loader_status.py
@@ -15,13 +15,64 @@ from loader_apps import app_url, sabotage
 
 pytestmark = [pytest.mark.site, pytest.mark.loader]
 
+ENGINE_LABEL = {"py": "Python", "r": "R"}
+
 
 @pytest.mark.allow_page_errors
-def test_missing_engine_asset_reports_the_status(page: Page, loader_delay: int) -> None:
-    sabotage(page, "py", "engine-load", loader_delay)
-    page.goto(app_url("py", "engine-load"))
+@pytest.mark.parametrize("engine", ["py", "r"])
+@pytest.mark.parametrize("mode", ["engine-load", "engine-unreachable"])
+def test_engine_failure_shows_the_recovery_hint(
+    page: Page, engine: str, mode: str, loader_delay: int
+) -> None:
+    """An engine that cannot load names the engine and offers the hint.
+
+    Absorbs viewer-error.test.tsx's first case. The hint is engine-only: an app
+    error is the author's to fix, so a hard refresh would not help.
+    """
+    sabotage(page, engine, mode, loader_delay)
+    page.goto(app_url(engine, mode))
+    expect(page.locator(".error-message")).to_have_text(
+        f"Error loading {ENGINE_LABEL[engine]}!"
+    )
+    expect(page.locator(".error-recovery")).to_be_visible()
+    log = page.locator(".error-log pre")
+    if mode == "engine-load":
+        expect(log).to_contain_text("404")
+    else:
+        expect(log).to_contain_text("unreachable")
+
+
+@pytest.mark.allow_page_errors
+def test_engine_setup_failure_replies_instead_of_hanging(
+    page: Page, loader_delay: int
+) -> None:
+    """Python only: webR has no setupPythonEnv() equivalent.
+
+    This is the window where the worker holds a live pyodide but no pyUtils.
+    Before the fix the error handler itself threw on the absent pyUtils, no
+    reply was posted, and the loader spun forever -- so the assertion that
+    matters is that an error screen appears at all.
+
+    Whether `page.route()` can even intercept the worker script (loaded via
+    `importScripts()`/`new Worker()`, not `fetch()`) is an open question this
+    test resolves: `sabotage()`'s handler installs first, then a second handler
+    on the same glob is layered on top of it purely to observe that *some*
+    handler ran for that URL before falling back to the real one. If neither
+    fires, `fired` stays empty and the assertion below -- not a silently-passing
+    page -- is what reports it.
+    """
+    sabotage(page, "py", "engine-setup", loader_delay)
+    fired = []
+    page.route(
+        "**/pyodide-worker.js",
+        lambda route: (fired.append(route.request.url), route.fallback()),
+    )
+    page.goto(app_url("py", "engine-setup"))
     expect(page.locator(".error-message")).to_have_text("Error loading Python!")
-    expect(page.locator(".error-log pre")).to_contain_text("404")
+    expect(page.locator(".error-log pre")).to_contain_text("ModuleNotFoundError")
+    assert fired, (
+        "no request for pyodide-worker.js was ever intercepted by page.route()"
+    )
 
 
 def test_an_unknown_mode_is_rejected_before_it_reaches_the_page() -> None:

--- a/tests/test_loader_status.py
+++ b/tests/test_loader_status.py
@@ -87,6 +87,26 @@ def test_r_syntax_error_reports_the_line(page: Page, loader_delay: int) -> None:
 
 
 @pytest.mark.allow_page_errors
+def test_r_failure_names_the_call(page: Page, loader_delay: int) -> None:
+    """conditionMessage() drops conditionCall(), so the dialog showed what
+    failed but not which call failed. stop() raises with a call attached, so
+    this is where the difference shows.
+    """
+    sabotage(page, "r", "r-runtime", loader_delay)
+    page.goto(app_url("r", "r-runtime"))
+    expect(page.locator(".error-message")).to_have_text("Error starting app!")
+    log = page.locator(".error-log pre")
+    expect(log).to_contain_text("Error in ")
+    expect(log).to_contain_text("deliberate failure")
+    # shiny evaluates the app's body inside ..stacktraceon..(), so the call this
+    # condition carries deparses to the whole app source. "unreachable" appears
+    # only in the app's ui line, which is past the first deparsed line: this is
+    # the assertion that .start_app truncates rather than pasting the app into
+    # the dialog.
+    expect(log).not_to_contain_text("unreachable")
+
+
+@pytest.mark.allow_page_errors
 def test_python_unresolvable_requirement_fails_the_app(
     page: Page, loader_delay: int
 ) -> None:

--- a/tests/test_loader_status.py
+++ b/tests/test_loader_status.py
@@ -1,0 +1,22 @@
+"""The loading overlay and the error screens, per failure mode.
+
+Replaces scripts/loader-demo.ts, which showed these by hand. See tests/README.md
+for how to watch one in a browser.
+"""
+
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import Page, expect
+
+from loader_apps import app_url, sabotage
+
+pytestmark = [pytest.mark.site, pytest.mark.loader]
+
+
+@pytest.mark.allow_page_errors
+def test_missing_engine_asset_reports_the_status(page: Page, loader_delay: int) -> None:
+    sabotage(page, "py", "engine-load", loader_delay)
+    page.goto(app_url("py", "engine-load"))
+    expect(page.locator(".error-message")).to_have_text("Error loading Python!")
+    expect(page.locator(".error-log pre")).to_contain_text("404")

--- a/tests/test_loader_status.py
+++ b/tests/test_loader_status.py
@@ -11,7 +11,7 @@ from typing import cast
 import pytest
 from playwright.sync_api import Page, expect
 
-from loader_apps import app_url, sabotage
+from loader_apps import MISSING_PKG, app_url, sabotage
 
 pytestmark = [pytest.mark.site, pytest.mark.loader]
 
@@ -52,27 +52,12 @@ def test_engine_setup_failure_replies_instead_of_hanging(
     Before the fix the error handler itself threw on the absent pyUtils, no
     reply was posted, and the loader spun forever -- so the assertion that
     matters is that an error screen appears at all.
-
-    Whether `page.route()` can even intercept the worker script (loaded via
-    `importScripts()`/`new Worker()`, not `fetch()`) is an open question this
-    test resolves: `sabotage()`'s handler installs first, then a second handler
-    on the same glob is layered on top of it purely to observe that *some*
-    handler ran for that URL before falling back to the real one. If neither
-    fires, `fired` stays empty and the assertion below -- not a silently-passing
-    page -- is what reports it.
     """
     sabotage(page, "py", "engine-setup", loader_delay)
-    fired = []
-    page.route(
-        "**/pyodide-worker.js",
-        lambda route: (fired.append(route.request.url), route.fallback()),
-    )
     page.goto(app_url("py", "engine-setup"))
     expect(page.locator(".error-message")).to_have_text("Error loading Python!")
+    expect(page.locator(".error-recovery")).to_be_visible()
     expect(page.locator(".error-log pre")).to_contain_text("ModuleNotFoundError")
-    assert fired, (
-        "no request for pyodide-worker.js was ever intercepted by page.route()"
-    )
 
 
 @pytest.mark.allow_page_errors
@@ -110,17 +95,43 @@ def test_python_unresolvable_requirement_fails_the_app(
     expect(page.locator(".error-message")).to_have_text("Error starting app!")
 
 
+@pytest.mark.allow_page_errors
 def test_r_unresolvable_library_still_runs(page: Page, loader_delay: int) -> None:
     """Deliberately not fatal (useWebR.tsx:371-376): renv::dependencies() also
     reports packages that are named but never used, and those apps run today.
-    No allow_page_errors -- this one is expected to be clean.
+
+    This opts out of conftest's fail_on_page_errors, so it asserts for itself
+    which console error is acceptable: webr::install() warning that it could
+    not find the never-used package, which reaches the console (rather than
+    the shinylive terminal) because it fires before the Terminal component
+    mounts and takes over App.tsx's "preload error:" fallback logger. Anything
+    else -- an unrelated error, or this one going silent -- still fails the
+    test.
     """
     from shinylive_app import wait_for_app_rendered
+
+    errors: list[str] = []
+    page.on(
+        "console", lambda m: errors.append(m.text) if m.type == "error" else None
+    )
 
     sabotage(page, "r", "requirements", loader_delay)
     page.goto(app_url("r", "requirements"))
     wait_for_app_rendered(page)
     expect(page.locator(".loading-wrapper-error")).to_have_count(0)
+
+    # R prints this warning as two lines -- "Warning in webr::install(...) :"
+    # and an indented message body -- each its own console.error() call, so
+    # both need to pass. Every line goes through App.tsx's "preload error:"
+    # fallback (see the docstring), and the body names the exact package this
+    # sabotage() mode injects, which is what rules out an unrelated error
+    # merely sharing that prefix.
+    assert errors, "expected webr::install()'s not-found warning on the console"
+    assert all(e.startswith("preload error:") for e in errors), errors
+    combined = "\n".join(errors)
+    missing_pkg_r_name = MISSING_PKG.replace("-", ".")
+    assert "webr::install" in combined, combined
+    assert f"{missing_pkg_r_name} not found in webR binary repo" in combined, combined
 
 
 def test_an_unknown_mode_is_rejected_before_it_reaches_the_page() -> None:

--- a/tests/test_loader_status.py
+++ b/tests/test_loader_status.py
@@ -88,22 +88,38 @@ def test_r_syntax_error_reports_the_line(page: Page, loader_delay: int) -> None:
 
 @pytest.mark.allow_page_errors
 def test_r_failure_names_the_call(page: Page, loader_delay: int) -> None:
-    """conditionMessage() drops conditionCall(), so the dialog showed what
-    failed but not which call failed. stop() raises with a call attached, so
-    this is where the difference shows.
+    """conditionMessage() drops conditionCall(), so the dialog said what failed
+    but not which call failed. A failure inside a function the app author wrote
+    is where the difference shows: R attaches that call to the condition.
+    """
+    sabotage(page, "r", "r-runtime-call", loader_delay)
+    page.goto(app_url("r", "r-runtime-call"))
+    expect(page.locator(".error-message")).to_have_text("Error starting app!")
+    log = page.locator(".error-log pre")
+    expect(log).to_contain_text("Error in load_data(")
+    expect(log).to_contain_text("deliberate failure")
+    # deparse() breaks a call wider than 60 characters across lines and
+    # .start_app keeps only the first, so the app's last argument is past the
+    # break: a dialog containing it would mean the truncation is gone.
+    expect(log).not_to_contain_text("truncated_marker")
+
+
+@pytest.mark.allow_page_errors
+def test_r_top_level_failure_shows_only_the_message(
+    page: Page, loader_delay: int
+) -> None:
+    """A top-level failure has no call of the author's to name: shiny evaluates
+    every app body inside ..stacktraceon.., so that wrapper is the only call the
+    condition carries, and deparsing it yields the whole app source.
+
+    .start_app drops a call from that family, which leaves exactly what the
+    dialog showed before it reported calls at all. The exact-text assertion is
+    what rules out both the wrapper's name and the app source behind it.
     """
     sabotage(page, "r", "r-runtime", loader_delay)
     page.goto(app_url("r", "r-runtime"))
     expect(page.locator(".error-message")).to_have_text("Error starting app!")
-    log = page.locator(".error-log pre")
-    expect(log).to_contain_text("Error in ")
-    expect(log).to_contain_text("deliberate failure")
-    # shiny evaluates the app's body inside ..stacktraceon..(), so the call this
-    # condition carries deparses to the whole app source. "unreachable" appears
-    # only in the app's ui line, which is past the first deparsed line: this is
-    # the assertion that .start_app truncates rather than pasting the app into
-    # the dialog.
-    expect(log).not_to_contain_text("unreachable")
+    expect(page.locator(".error-log pre")).to_have_text("deliberate failure")
 
 
 @pytest.mark.allow_page_errors

--- a/tests/test_loader_status.py
+++ b/tests/test_loader_status.py
@@ -108,8 +108,9 @@ def test_r_syntax_error_reports_the_line(page: Page, loader_delay: int) -> None:
     sabotage(page, "r", "app-syntax", loader_delay)
     page.goto(app_url("r", "app-syntax"))
     log = page.locator(".error-log pre")
-    # The R fixture ships a second, valid .R file, so this also pins which of the
-    # files the guard iterated is named as the one that failed.
+    # The R fixture ships a second, valid .R file that sorts before app.R, so
+    # this also pins that the failing file named here is app.R, not the one the
+    # guard parsed first.
     expect(log).to_contain_text("app.R:")
     expect(log).to_contain_text("^")
     # The guard re-raises without the condition's call, which would otherwise be
@@ -278,9 +279,8 @@ _EMBED_VIEWER_HEIGHT = 320
 def _codeblock_body(files: list[dict[str, str]]) -> str:
     """Render a file set as a shinylive code-block body.
 
-    Mirrors codeBlockBody() in scripts/loader-demo.ts: a single file needs no
-    header, and more than one uses the '## file:' syntax parse-codeblock.ts
-    understands.
+    A single file needs no header; a multi-file block needs a '## file:'
+    header per file, the syntax src/parse-codeblock.ts understands.
     """
     if len(files) == 1:
         return files[0]["content"]
@@ -312,8 +312,9 @@ def embed_page(page: Page, engine: str, mode: str) -> Iterator[str]:
     resolve against the real files `static_server` serves -- only this one URL
     is intercepted; every other request passes through untouched.
 
-    Modeled on scripts/loader-demo.ts's embedPage()/buildDemoSite() -- the last
-    known-working generator of this markup, since replaced by this test.
+    An embedded shinylive app block needs `#| standalone: true` --
+    parse-codeblock.ts throws if a viewer block lacks it -- or the block
+    renders as a static code sample instead of a live app.
     """
     body = _codeblock_body(_files(engine, mode))
     html = f"""<!doctype html>
@@ -385,9 +386,9 @@ def test_embedded_block_shows_the_error(
 def test_an_unknown_mode_is_rejected_before_it_reaches_the_page() -> None:
     """A typo'd mode string should fail loudly at the call, not silently at
     the assertion. `_files()` and `sabotage()`'s guards run before either
-    function touches a page, so this needs neither a browser nor
-    `allow_page_errors`: the page passed to `sabotage()` here is a stand-in
-    that would blow up if the guard did not raise first.
+    function touches a page, so this needs no `allow_page_errors`: the page
+    passed to `sabotage()` here is a stand-in that would blow up if the guard
+    did not raise first.
     """
     with pytest.raises(ValueError):
         app_url("py", "bogus-mode")


### PR DESCRIPTION
## Problem

On a first visit to a site using shinylive, the app-loading overlay shows the pulsing hex animation with no text. Behind the scenes, a multi-megabyte Pyodide or webR engine is downloaded plus package installs, which can take tens of seconds (or longer on slow connections), so a slow first load doesn't give any feedback about if something useful is happening during that time. Generally speaking, I wanted to address "could the shinylive loader show a bit more help text on first load?"

Related: #192 (long loading times) describes the underlying slowness, which this does not attempt to fix.

## What changed

Two things, primarily:

**1. The overlay says what it is doing.** Under the existing hex animation:

- `Downloading Python…` → `Starting Python…` → `Loading packages and starting app…`
- and the R equivalents (`Downloading R…`, `Starting R…`)

The text only appears after a **3 second delay**, so a fast load (from cache) looks essentially as it did before.

A store implemented per engine in `src/load-status.ts` keeps track of the various loading stages.

**2. Failures produce an error screen instead of just endlessly pulsing.** 

The following conditions were tested:

| failure | before | after |
| --- | --- | --- |
| Engine wasm missing, or host unreachable | spun forever, no error | error in ~0.2s, naming the URL and the status |
| Worker reports an init failure (e.g. `pyodide-lock.json` 404) | discarded; surfaced later as an unrelated error | the real cause, in under a second |
| R app fails to start (e.g. syntax error) | app marked running, blank frame, error only in the terminal — and **nothing at all in an embed** | `Error starting app!`, naming the line and showing the offending source line |
| any of the above | traceback only | leads with hard-refresh / clear-cache advice |

Specifically, these limitations came from:

- **Engine wasm.** Neither `loadPyodide()` nor webR's `init()` settles when the core wasm app cannot be instantiated; its promise is neither resolved nor rejected, so there were no error signals the page can catch. `src/engine-load-guard.ts` checks that at least the wasm file is fetchable before the engine starts, and fails early if not.
- **`WebWorkerPyodideProxy.init()`** discarded the worker's error reply, so a Pyodide that never started would appear successful.
- **R app startup.** `.start_app` (in `useWebR.tsx`) is evaluated with `captureConditions = FALSE`: with this setting an R error makes `evalR` *resolve* rather than reject, so a raised error would go to the terminal and never reach JavaScript. `.start_app` therefore reports its outcome by returning a value. It returns `list(status = "ok")`, or `list(status = "error", message, class, call)` on failure. An earlier revision of this PR returned `""` for success and the message for failure, which made a condition carrying an empty message indistinguishable from success; the status list removes that. `Viewer.tsx` reads it with `evalR` + `toJs()` through the shelter it already opens and purges, rather than `evalRString`. The condition's `class` now reaches the console for diagnosis, and `call` is reported only when it names the author's own code — shiny wraps every app body in `..stacktraceon..()`, so a top-level failure's raw call is the whole app source, and that wrapper is filtered out. Flipping `captureConditions` to `TRUE` would also have fixed the original problem, but it changes error handling for every R call rather than just app startup. Package installation stays non-fatal on purpose — see the R note under Testing.
- **R syntax errors get a line number.** shiny's `sourceUTF8` catches the parse error and raises only `Error sourcing <file>`, discarding the detail. `.start_app` now quickly parses the app's top-level `.R` files before shiny sees them, so the real parse error including line, column, offending line and caret, reaches the viewer. It runs before the VFS mount and package installs, so a typo fails in a couple of seconds instead of after work the app cannot use.
- **User-facing advice.** There is deliberately no reload button: a reload triggered from JS cannot bypass the cache, so the error instead suggests the user to hard-refresh, as that is a possible solution in some cases.

### One known failure-mode limitation

An engine asset that downloads but cannot be *instantiated*, for example a truncated file, or an HTML error page served with 200, will still cause the loading hexes to spin with no error screen. Closing it needs either byte-level validation or a timeout. I had a timeout implemented, but removed it because it was a messy catch for a rare problem and definitely overengineered

## Architecture

The `load-status.ts` observable store controls the "status" of the engine and app load. `App.tsx` writes into the store via `initPyodide` or `initWebR`, and then `Viewer.tsx` responds to changes in the store to control what's shown to the user:

```mermaid
flowchart TB
    A["<b>App.tsx</b><br/>starts engine init, once per page"]
    B["<b>initPyodide / initWebR</b><br/>guard the asset, then boot the engine"]
    S["<b>load-status.ts</b><br/>one store per engine"]
    H["<b>useLoadStatus.ts</b><br/>useSyncExternalStore"]
    V["<b>Viewer.tsx</b>"]
    L["LoadingStatus.tsx<br/>stage text, after 3s"]
    E["ViewerError<br/>failure screen"]

    A --> B
    B -- "set(stage)" --> S
    S -- "subscribe" --> H
    H --> V
    V -- "loading" --> L
    V -- "failed" --> E

    classDef store fill:#fde8c8,stroke:#b8860b
    class S store
```

Stages are linear and one-way:
`engine-download` → `engine-start` → `ready`, or `failed`, which is terminal and causes an error to be displayed in the UI.

### How a failure reaches the screen

Failures were previously just silently discarded and the loading icon would endlessly pulse. Now, error sources fan into two distinct types of errors:

```mermaid
flowchart LR
    G["<b>guard</b><br/>wasm 404, host unreachable,<br/>not a wasm module"]
    W["<b>worker</b><br/>pyodide init error reply<br/><i>pyodide-proxy.ts:388</i>"]
    P["<b>engine init</b><br/>load_python_pre / load_r_pre,<br/>initShiny / initRShiny throws"]
    PA["<b>Python app</b><br/>_start_app throws<br/><i>Viewer.tsx:381</i>"]
    RA["<b>R app</b><br/>.start_app returns a status list<br/><i>Viewer.tsx:331</i>"]
    C["<b>cosmetic</b><br/>terminal clear, start banner"]

    F["stage = <b>failed</b><br/><i>terminal</i>"]
    X["appRunningState<br/>= <b>errored</b>"]
    LOG(["console.error only<br/><i>app keeps running</i>"])

    E1["<b>ViewerError kind='engine'</b><br/><i>+ recovery hint</i>"]
    E2["<b>ViewerError kind='app'</b><br/><i>traceback only</i>"]

    G --> F
    W --> F
    P --> F
    PA --> X
    RA --> X
    C --> LOG
    F --> E1
    X --> E2

    classDef prior fill:#f2f2f2,stroke:#aaa,color:#666
    classDef dead fill:#eef6ee,stroke:#8ab88a,color:#456
    class PA prior
    class LOG dead
```

The python app failure was the only one that already reached the screen before this PR. Everything else was silent.

The engine/app split determines the advice that gets shown to the user. The hard-refresh / clear-cache hint appears *only* on the engine side. On the app side the engine already loaded fine, so the cache isn't the suspect and the hint would point the reader away from the traceback sitting right below it (commit `6f99001`).

## Example Recordings

The following screen recordings demonstrate what this looks like in a few different scenarios, both with throttling to simulate a slow connection, and on a fast connection. There are both R and Python examples here, in an "embed"/Quarto type display, as well as the full screen height version like on https://shinylive.io/py/examples/ 

<table>
<thead>
<tr><th></th><th>Python</th><th>R</th></tr>
</thead>
<tbody>
<tr>
<td><strong>Full page &mdash; throttled</strong></td>
<td>
<video src="https://github.com/user-attachments/assets/df799a68-8d87-4c11-a3dc-bbd6af40e53c" controls width="440"></video>
</td>
<td>
<video src="https://github.com/user-attachments/assets/ca1bdc24-e240-4ce9-856c-0035e3a50890" controls width="440"></video>
</td>
</tr>
<tr>
<td><strong>Full page &mdash; unthrottled</strong></td>
<td>
<video src="https://github.com/user-attachments/assets/2c99b6ff-14fc-4984-bc32-3d47fc50144f" controls width="440"></video>
</td>
<td>
<video src="https://github.com/user-attachments/assets/7d3df46c-2613-44a1-8f1d-c974192755c5" controls width="440"></video>
</td>
</tr>
<tr>
<td><strong>Embedded (Quarto) &mdash; throttled</strong></td>
<td>
<video src="https://github.com/user-attachments/assets/85c3f9bb-a503-4778-8e83-63edaf94d625" controls width="440"></video>
</td>
<td>
<video src="https://github.com/user-attachments/assets/3326d7fd-dd82-40b1-8188-df4c34786530
" controls width="440"></video>
</td>
</tr>
<tr>
<td><strong>Embedded (Quarto) &mdash; unthrottled</strong></td>
<td>
<video src="https://github.com/user-attachments/assets/a4b2c7d3-0a25-42e7-96fa-631351384457" controls width="440"></video>
</td>
<td>
<video src="https://github.com/user-attachments/assets/9f74c1e3-2f8d-419a-8b85-5172d31752fc" controls width="440"></video>
</td>
</tr>
</tbody>
</table>


## Testing

Both test layers this PR needed landed while it was open: #246 added the jest unit harness and a `tsc --noEmit` CI gate, and #247 moved browser testing to pytest + Playwright under `tests/`. This PR uses both, so the manual verification below is now automated.

**Unit tests — 37, jest.** `src/load-status.test.ts` covers the status store: subscription semantics that `useSyncExternalStore` depends on, per-engine isolation, and `failed` being terminal. `src/engine-load-guard.test.ts` covers the reachability and wasm-magic-number checks against a stubbed `fetch`, including a magic number split across chunks, a body that cannot be cancelled, and one that throws mid-read. Coverage over the modules these import is 100% on all four metrics.

**Browser tests — 19, pytest + Playwright, `-m loader`.** `tests/test_loader_status.py` drives every mode in the table below end to end against the built site, for both engines, in both the full-page and embedded layouts. App source travels in the URL hash, so app-level failures need no interception; engine-level ones use `page.route()`. Two choices worth a reviewer's eye: the staged-loading test records transitions with an in-page `MutationObserver` rather than polling assertions, because a delay injected in a sync route handler blocks Playwright's own connection thread; and the delay is a `--loader-delay` option rather than CDP throttling, so assertions are on the observed order of stages and never on elapsed time.

`scripts/loader-demo.ts`, the local script behind the recordings above, is deleted. `tests/README.md` documents the equivalent recipes — `--headed --slowmo`, `--video on`, `--tracing on` with `playwright show-trace`, and turning `--loader-delay` up to watch the stages by hand.

The table below was the original manual verification; every row now has a test.

| mode | Python | R |
| --- | --- | --- |
| healthy load | app runs <img width="756" height="352" alt="image" src="https://github.com/user-attachments/assets/120e833f-48c4-46af-8699-96dbb019e873" />| app runs <img width="736" height="432" alt="image" src="https://github.com/user-attachments/assets/16b0d6bb-8b29-473f-979d-37569ae9950f" /> |
| core wasm 404 | error in 0.2s, names URL + status <img width="1204" height="772" alt="image" src="https://github.com/user-attachments/assets/dab961dc-e6df-4575-82f7-def151c1a06c" /> | same <img width="1188" height="720" alt="image" src="https://github.com/user-attachments/assets/cbcf7a55-8530-4e11-a3f8-4132be67ef72" /> |
| connection dropped for the core wasm | error in 0.2s, reported as unreachable <img width="1152" height="748" alt="image" src="https://github.com/user-attachments/assets/e1edee11-a8c5-4966-9ac7-34d018f9f1c1" /> | same <img width="1216" height="708" alt="image" src="https://github.com/user-attachments/assets/e3e462a3-51c7-46da-b90e-11c6c437a236" /> |
| syntax error in app source | `Error starting app!` + traceback <img width="1308" height="1246" alt="image" src="https://github.com/user-attachments/assets/0e1f3758-76c9-4a67-8ce9-9c6717a794b0" /> | `Error starting app!` + `app.R:7:1: unexpected symbol` with the offending line and caret **(new — previously silent in an embed)** <img width="1204" height="752" alt="image" src="https://github.com/user-attachments/assets/5479e178-c6bc-4ea9-84a9-893a78d701ec" /> |
| unresolvable dependency | `Error starting app!` + micropip's `ValueError` <img width="1190" height="1616" alt="image" src="https://github.com/user-attachments/assets/d243dcc1-6b58-4a0f-9f6a-dcf9b0018fb3" /> | warnings only; the app genuinely runs — see below <img width="1768" height="832" alt="image" src="https://github.com/user-attachments/assets/ffc9f2ae-7a54-4b65-b5d1-e89042815ca2" /> |

**On the R dependency case.** R has no `requirements.txt`; dependencies are inferred from the source by `renv::dependencies()`, and a missing one is tolerated. `library()` is shimmed by webR (`environmentName` reports `webr`) and returns normally instead of erroring, so the app really does start. That appears to be upstream's intended behaviour, which may also be why `.start_app` does not treat a failed install as fatal — `renv::dependencies()` reports packages that are never used (a `library()` call inside `if (FALSE)` is reported, and that app runs fine), so failing on it could break working apps.

**CI placement.** The loader tests carry both the `site` and `loader` markers, and the Make targets split on that: `make test-site` is `-m "site and not loader"`, `make test-loader` is `-m loader`. Between them they cover every `site` test, so running one is not running them all.

`make test-site` stays where it was, in `build.yml`'s build job, so a failure in the editor, URL-loading or static-export tests still stops the deploy that follows. The loader tests move to a new `test-loader.yml`, for the same reason `test-apps.yml` exists: they are slow — nearly every one boots a real Pyodide or webR instance, so the suite costs about as much as all the other site tests together — and they should not sit in front of an S3 deploy. Being a separate workflow also gets them a `cancel-in-progress` concurrency group, which `build.yml` cannot have without risking a cancelled deploy.

They therefore do not gate anything yet, which is deliberate and worth revisiting once they have some green history. CI has already earned that caution: the first run of this branch failed on an intermittent console-error assertion that passes locally and passed on the next run, which is exactly what gating would have turned into a blocked deploy. That bug is fixed — the test was collecting console errors itself after opting out of `fail_on_page_errors`, but had reimplemented the collection without the fixture's forgiveness for the tag-manager requests `block_analytics` aborts, which only exist where `GOOGLE_TAG_MANAGER_ID` is set. The predicate now lives in one place and both callers share it.

Moving the gate later means either folding the marker back into `make test-site`, or triggering the deploy from `test-loader.yml`'s success via `workflow_run`.

**Verification.** `make type-check` clean; `npm run test:unit` 328/328; `npm run test:unit:coverage` 100% on all four metrics; `venv/bin/pytest tests -m site` 34/34.


