### PR TITLE
test: strengthen example intent coverage

### DIFF
--- a/examples/python/app_with_plot/app.py
+++ b/examples/python/app_with_plot/app.py
@@ -3,7 +3,7 @@ import numpy as np
 from shiny.express import ui, input, render
 
 with ui.sidebar():
-    ui.input_slider("n", "N", 0, 100, 20)
+    ui.input_slider("n", "N", 1, 100, 20)
 
 
 @render.plot(alt="A histogram")

--- a/tests/README.md
+++ b/tests/README.md
@@ -8,6 +8,10 @@ output in a real browser:
 - **`test_examples_intent_py.py`** and **`test_examples_intent_r.py`** go further
   for each app: drive its inputs, and check the outputs that depend on them.
 
+Every test also fails on terminal tracebacks or warnings, Shiny output errors,
+and browser console errors, including errors emitted after an intent-test
+interaction.
+
 ```console
 make examples-test-deps     # once
 make all                    # the tests drive the built output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,13 +9,56 @@ import time
 from typing import Iterator
 
 import pytest
+from playwright.sync_api import ConsoleMessage, Page
 from playwright.sync_api import expect
 
-from shinylive_app import SHINYLIVE_DIR, STATIC_PORT
+from shinylive_app import (
+    APP_FRAME,
+    SHINYLIVE_DIR,
+    STATIC_PORT,
+    suspect_terminal_lines,
+    terminal_text,
+)
 
 # Assertions get their own timeout, well short of the per-test one: an app that
 # is going to answer at all answers long before this.
 expect.set_options(timeout=30_000)
+
+
+@pytest.fixture(autouse=True)
+def fail_on_example_errors(page: Page) -> Iterator[None]:
+    """Fail on errors emitted while an example is starting or being exercised."""
+    console_errors: list[str] = []
+
+    def on_console(message: ConsoleMessage) -> None:
+        if message.type != "error":
+            return
+        # A missing favicon is not an app problem.
+        if message.location["url"].endswith("favicon.ico"):
+            return
+        console_errors.append(message.text)
+
+    page.on("console", on_console)
+    page.on("pageerror", lambda error: console_errors.append(str(error)))
+
+    yield
+
+    # Give debounced inputs and reactive effects time to surface asynchronous
+    # errors before checking the final page state.
+    page.wait_for_timeout(500)
+
+    terminal = terminal_text(page)
+    suspect_lines = suspect_terminal_lines(terminal)
+    assert suspect_lines == [], (
+        "unexpected output in the shinylive terminal:\n" + terminal
+    )
+    expect(
+        page.frame_locator(APP_FRAME).locator(".shiny-output-error"),
+        "app rendered an output error",
+    ).to_have_count(0)
+    assert console_errors == [], "browser console errors:\n" + "\n".join(
+        console_errors
+    )
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:

--- a/tests/shinylive_app.py
+++ b/tests/shinylive_app.py
@@ -313,16 +313,23 @@ def brush(
     page.wait_for_timeout(500)
 
 
-def wait_until(page: Page, predicate: Callable[[], bool], message: str) -> None:
-    """Poll `predicate` until it holds, or fail with `message`.
+def wait_until(
+    page: Page,
+    predicate: Callable[[], bool],
+    message: str,
+    *,
+    timeout: float = 10_000,
+) -> None:
+    """Poll `predicate` until it holds or `timeout` milliseconds elapse.
 
     For the handful of assertions that are about a value changing rather than a
     locator settling, which is all playwright's own expectations cover.
     """
-    for _ in range(60):
+    interval = 250
+    for _ in range(round(timeout / interval)):
         if predicate():
             return
-        page.wait_for_timeout(500)
+        page.wait_for_timeout(interval)
     raise AssertionError(message)
 
 

--- a/tests/test_examples_intent_py.py
+++ b/tests/test_examples_intent_py.py
@@ -117,8 +117,10 @@ def test_regularization(page: Page) -> None:
         plot.expect_rendered()
 
     before = [plot.loc_img.get_attribute("src") for plot in plots]
-    strength.set("0.2")
-    strength.expect_value("0.2")
+    # Use the exact maximum so the test does not depend on browser-specific
+    # floating-point labels for intermediate slider steps.
+    strength.set("1")
+    strength.expect_value("1")
     for plot, src in zip(plots, before):
         playwright_expect(plot.loc_img).not_to_have_attribute("src", src or "")
 
@@ -144,12 +146,14 @@ def test_altair(page: Page) -> None:
     variable.expect_selected(["bill_length_mm"])
     playwright_expect(chart_surface).to_be_visible()
 
-    before = chart_surface.screenshot()
+    # The widget replaces its canvas during a redraw, but its output container
+    # stays attached to the DOM.
+    before = chart.screenshot()
     variable.set("body_mass_g")
     variable.expect_selected(["body_mass_g"])
     wait_until(
         page,
-        lambda: chart_surface.screenshot() != before,
+        lambda: chart.screenshot() != before,
         "expected the Altair chart to update",
     )
 

--- a/tests/test_examples_intent_py.py
+++ b/tests/test_examples_intent_py.py
@@ -54,6 +54,7 @@ def test_app_with_plot(page: Page) -> None:
     histogram = OutputPlot(app, "histogram")
 
     sidebar(app).expect_open(True)
+    n.expect_min("1")
     n.expect_value("20")
     histogram.expect_rendered()
     histogram.expect_img_alt("A histogram")
@@ -65,31 +66,61 @@ def test_app_with_plot(page: Page) -> None:
 def test_cpuinfo(page: Page) -> None:
     app = open_example(page, "py", "CPU info")
     cmap = controller.InputSelect(app, "cmap")
+    hold = controller.InputSwitch(app, "hold")
 
     cmap.expect_choices(["inferno", "viridis", "copper", "prism"])
     cmap.expect_selected("inferno")
-    controller.InputSwitch(app, "hold").expect_checked(False)
+    hold.expect_checked(False)
     controller.InputActionButton(app, "reset").expect_label("Clear history")
 
     graphs, heatmap = NavPanel(app, "Graphs"), NavPanel(app, "Heatmap")
     graphs.expect_active(True)
     OutputPlot(app, "plot").expect_rendered()
 
+    # Freeze the sample history so the heatmap only changes in response to the
+    # controls exercised below, rather than its once-per-second timer.
+    hold.set(True)
+    hold.expect_checked(True)
+    page.wait_for_timeout(1500)
+
     # The heatmap is a table with one column per (fake) CPU.
     heatmap.click()
     heatmap.expect_active(True)
     controller.InputNumeric(app, "table_rows").expect_value("15")
-    controller.OutputTable(app, "table").expect_ncol(8)
+    table = controller.OutputTable(app, "table")
+    table.expect_ncol(8)
+
+    before = table.loc.inner_html()
+    page.wait_for_timeout(1200)
+    assert table.loc.inner_html() == before, "frozen CPU history kept changing"
+    cmap.set("viridis")
+    cmap.expect_selected("viridis")
+    wait_until(
+        page,
+        lambda: table.loc.inner_html() != before,
+        "expected the colormap to update the heatmap",
+    )
 
 
 def test_regularization(page: Page) -> None:
     app = open_example(page, "py", "Regularization")
+    strength = controller.InputSlider(app, "a")
+    plots = [
+        OutputPlot(app, "plot"),
+        OutputPlot(app, "plotVOWELS"),
+        OutputPlot(app, "plotCONSONANTS"),
+    ]
 
-    controller.InputSlider(app, "a").expect_value("0.1")
+    strength.expect_value("0.1")
     # One simulation feeds all three plots through a reactive calc.
-    OutputPlot(app, "plot").expect_rendered()
-    OutputPlot(app, "plotVOWELS").expect_rendered()
-    OutputPlot(app, "plotCONSONANTS").expect_rendered()
+    for plot in plots:
+        plot.expect_rendered()
+
+    before = [plot.loc_img.get_attribute("src") for plot in plots]
+    strength.set("0.2")
+    strength.expect_value("0.2")
+    for plot, src in zip(plots, before):
+        playwright_expect(plot.loc_img).not_to_have_attribute("src", src or "")
 
 
 def test_plotly(page: Page) -> None:
@@ -107,26 +138,40 @@ def test_altair(page: Page) -> None:
     app = open_example(page, "py", "altair")
     variable = InputSelectize(app, "var")
     chart = app.locator("#hist.shiny-ipywidget-output")
+    chart_surface = chart.locator("canvas, svg").first
 
     variable.expect_choices(["bill_length_mm", "body_mass_g"])
     variable.expect_selected(["bill_length_mm"])
-    playwright_expect(chart.locator("canvas, svg").first).to_be_visible()
+    playwright_expect(chart_surface).to_be_visible()
 
+    before = chart_surface.screenshot()
     variable.set("body_mass_g")
     variable.expect_selected(["body_mass_g"])
-    playwright_expect(chart.locator("canvas, svg").first).to_be_visible()
+    wait_until(
+        page,
+        lambda: chart_surface.screenshot() != before,
+        "expected the Altair chart to update",
+    )
 
 
 def test_ipyleaflet(page: Page) -> None:
     app = open_example(page, "py", "Map")
     center = controller.InputSelect(app, "center")
+    map_widget = app.locator("#map .leaflet-container")
+    map_pane = map_widget.locator(".leaflet-map-pane")
 
     center.expect_choices(["London", "Paris", "New York"])
     center.expect_selected("London")
-    playwright_expect(app.locator("#map .leaflet-container")).to_be_visible()
+    playwright_expect(map_widget).to_be_visible()
 
+    before = map_pane.get_attribute("style")
     center.set("Paris")
     center.expect_selected("Paris")
+    wait_until(
+        page,
+        lambda: map_pane.get_attribute("style") != before,
+        "expected the map viewport to move",
+    )
 
 
 def test_multiple_source_files(page: Page) -> None:
@@ -218,16 +263,37 @@ def test_extra_packages(page: Page) -> None:
 
 
 def test_fetch(page: Page) -> None:
+    page.context.route(
+        "https://goweather.herokuapp.com/weather/**",
+        lambda route: route.fulfill(
+            status=200,
+            headers={
+                "access-control-allow-origin": "*",
+                "content-type": "application/json",
+            },
+            body=(
+                '{"temperature":"20 C","wind":"10 km/h",'
+                '"description":"Test sunshine"}'
+            ),
+        ),
+    )
     app = open_example(page, "py", "Fetch data from a web API")
     city = InputSelectize(app, "city")
     data_type = controller.InputRadioButtons(app, "data_type")
+    info = controller.OutputCode(app, "info")
 
-    # No city is selected on startup, so the app makes no request -- which is
-    # what keeps this test off the network.
     city.expect_selected([""])
     data_type.expect_choices(["json", "string", "bytes"])
     data_type.expect_selected("json")
-    controller.OutputCode(app, "info").expect_value("")
+    info.expect_value("")
+
+    city.set("Paris")
+    city.expect_selected(["Paris"])
+    info.expect.to_contain_text(
+        "Request URL: https://goweather.herokuapp.com/weather/Paris"
+    )
+    info.expect.to_contain_text("Result type: <class 'dict'>")
+    info.expect.to_contain_text("Test sunshine")
 
 
 def test_brand(page: Page) -> None:
@@ -531,7 +597,7 @@ def test_plot_interact_exclude(page: Page) -> None:
 
     # Brushing the left of the panel covers some of the scatter but not all of
     # it; toggling drops whatever was brushed and refits.
-    brush(page, plot1, 0.2, 0.15, 0.55, 0.85)
+    brush(page, plot1, 0.25, 0.2, 0.4, 0.8)
     controller.InputActionButton(app, "exclude_toggle").click()
     wait_until(
         page,

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -18,4 +18,5 @@ EXAMPLES = [(engine, title) for engine in ENGINES for title in example_app_title
     "engine,title", EXAMPLES, ids=[f"{engine}-{title}" for engine, title in EXAMPLES]
 )
 def test_example_app_starts_cleanly(page: Page, engine: str, title: str) -> None:
+    # fail_on_example_errors fixture (autouse=true) will test for console errors.
     open_example(page, engine, title)

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -7,17 +7,9 @@ the engine session is not shared between them.
 from __future__ import annotations
 
 import pytest
-from playwright.sync_api import ConsoleMessage, Page
-from playwright.sync_api import expect as playwright_expect
+from playwright.sync_api import Page
 
-from shinylive_app import (
-    APP_FRAME,
-    ENGINES,
-    example_app_titles,
-    open_example,
-    suspect_terminal_lines,
-    terminal_text,
-)
+from shinylive_app import ENGINES, example_app_titles, open_example
 
 EXAMPLES = [(engine, title) for engine in ENGINES for title in example_app_titles(engine)]
 
@@ -26,28 +18,4 @@ EXAMPLES = [(engine, title) for engine in ENGINES for title in example_app_title
     "engine,title", EXAMPLES, ids=[f"{engine}-{title}" for engine, title in EXAMPLES]
 )
 def test_example_app_starts_cleanly(page: Page, engine: str, title: str) -> None:
-    console_errors: list[str] = []
-
-    def on_console(message: ConsoleMessage) -> None:
-        if message.type != "error":
-            return
-        # A missing favicon is not an app problem.
-        if message.location["url"].endswith("favicon.ico"):
-            return
-        console_errors.append(message.text)
-
-    page.on("console", on_console)
-    page.on("pageerror", lambda error: console_errors.append(str(error)))
-
     open_example(page, engine, title)
-
-    assert suspect_terminal_lines(terminal_text(page)) == [], (
-        f"{title}: unexpected output in the shinylive terminal"
-    )
-
-    playwright_expect(
-        page.frame_locator(APP_FRAME).locator(".shiny-output-error"),
-        f"{title}: app rendered an output error",
-    ).to_have_count(0)
-
-    assert console_errors == [], f"{title}: browser console errors"


### PR DESCRIPTION
## Summary

This change detects errors that occur after an intent test interacts with an example. A shared fixture checks terminal output, Shiny output errors, browser console errors, and page errors.

The Python intent tests now confirm these results:

- CPU Info updates the heatmap after a colormap change.
- Regularization redraws all three dependent plots.
- Altair redraws its chart after a variable change.
- Map moves its viewport after a city change.
- Fetch renders a mocked API response without an external request.
